### PR TITLE
perf: run independent hardware probes asynchronously

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2670,9 +2670,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -4566,9 +4566,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -12,6 +12,10 @@ class ModelDatabase {
         this.dbPath = options.dbPath || path.join(os.homedir(), '.llm-checker', 'models.db');
         this.seedDbPath = options.seedDbPath || path.join(__dirname, 'seed', 'models.db');
         this.db = null;
+        this.sqliteBackend = options.sqliteBackend || 'auto';
+        if (!['auto', 'native', 'wasm'].includes(this.sqliteBackend)) {
+            throw new Error(`Unknown SQLite backend: ${this.sqliteBackend}`);
+        }
         this.initialized = false;
         this.disableRegistrySeedImport = Boolean(options.disableRegistrySeedImport);
         // Batched-write state: during a bulk sync we defer the (expensive) full
@@ -46,23 +50,34 @@ class ModelDatabase {
         }
         this.seedDatabaseIfNeeded();
 
-        // Use sql.js (optional dependency)
-        let initSqlJs;
-        try {
-            initSqlJs = require('sql.js');
-        } catch (e) {
-            throw new Error('sql.js is not installed. Install it with: npm install sql.js');
+        let DatabaseSync;
+        if (this.sqliteBackend !== 'wasm') {
+            try {
+                ({ DatabaseSync } = require('node:sqlite'));
+            } catch (error) {
+                if (this.sqliteBackend === 'native' || !['ERR_UNKNOWN_BUILTIN_MODULE', 'MODULE_NOT_FOUND'].includes(error.code)) {
+                    throw error;
+                }
+            }
         }
-        const SQL = await initSqlJs();
-
-        // Load existing database or create new
-        if (fs.existsSync(this.dbPath)) {
-            const buffer = fs.readFileSync(this.dbPath);
-            this.db = new SQL.Database(buffer);
+        this.useNativeSqlite = Boolean(DatabaseSync);
+        if (DatabaseSync) {
+            // Keep the file on disk; do not allocate a WASM heap or read it all.
+            // Opening errors must surface, rather than retrying with another engine.
+            this.db = new DatabaseSync(this.dbPath);
+            this.db.exec('PRAGMA busy_timeout = 5000');
         } else {
-            this.db = new SQL.Database();
+            let initSqlJs;
+            try {
+                initSqlJs = require('sql.js');
+            } catch {
+                throw new Error('This Node version requires sql.js. Install it with: npm install sql.js');
+            }
+            const SQL = await initSqlJs();
+            this.db = fs.existsSync(this.dbPath)
+                ? new SQL.Database(fs.readFileSync(this.dbPath))
+                : new SQL.Database();
         }
-        this.useBetterSqlite = false;
 
         this.createSchema();
         this.migrateSpeedBenchmarks();
@@ -237,7 +252,7 @@ class ModelDatabase {
             DROP INDEX IF EXISTS idx_model_artifacts_runtime;
         `;
 
-        if (this.useBetterSqlite) {
+        if (this.useNativeSqlite) {
             this.db.exec(schema);
         } else {
             this.db.run(schema);
@@ -290,7 +305,7 @@ class ModelDatabase {
      * Save sql.js database to file
      */
     saveToFile() {
-        if (!this.useBetterSqlite && this.db) {
+        if (!this.useNativeSqlite && this.db) {
             const data = this.db.export();
             const buffer = Buffer.from(data);
             // Write to a temp file then atomically rename, so a crash/SIGINT
@@ -307,12 +322,19 @@ class ModelDatabase {
      * instead of on every row. Nestable; the outermost endBatch() flushes.
      */
     beginBatch() {
+        if (this.useNativeSqlite && this._batchDepth === 0) {
+            this.db.exec('SAVEPOINT llm_checker_batch');
+        }
         this._batchDepth += 1;
     }
 
     endBatch() {
         if (this._batchDepth > 0) {
             this._batchDepth -= 1;
+            if (this.useNativeSqlite && this._batchDepth === 0) {
+                this.db.exec('RELEASE llm_checker_batch');
+                this._pendingSave = false;
+            }
         }
         if (this._batchDepth === 0 && this._pendingSave) {
             this.saveToFile();
@@ -323,7 +345,7 @@ class ModelDatabase {
      * Execute a query (handles both sqlite implementations)
      */
     run(sql, params = []) {
-        if (this.useBetterSqlite) {
+        if (this.useNativeSqlite) {
             return this.db.prepare(sql).run(...params);
         } else {
             this.db.run(sql, params);
@@ -339,8 +361,8 @@ class ModelDatabase {
      * Get all results from a query
      */
     all(sql, params = []) {
-        if (this.useBetterSqlite) {
-            return this.db.prepare(sql).all(...params);
+        if (this.useNativeSqlite) {
+            return this.db.prepare(sql).all(...params).map((row) => ({ ...row }));
         } else {
             const stmt = this.db.prepare(sql);
             stmt.bind(params);
@@ -357,8 +379,9 @@ class ModelDatabase {
      * Get single result from a query
      */
     get(sql, params = []) {
-        if (this.useBetterSqlite) {
-            return this.db.prepare(sql).get(...params);
+        if (this.useNativeSqlite) {
+            const row = this.db.prepare(sql).get(...params);
+            return row ? { ...row } : null;
         } else {
             const results = this.all(sql, params);
             return results.length > 0 ? results[0] : null;
@@ -1263,14 +1286,12 @@ class ModelDatabase {
      * Close database connection
      */
     close() {
-        if (this.db) {
-            if (this.useBetterSqlite) {
-                this.db.close();
-            } else {
-                this.saveToFile();
-                this.db.close();
-            }
-        }
+        if (!this.db) return;
+        while (this._batchDepth > 0) this.endBatch();
+        if (!this.useNativeSqlite) this.saveToFile();
+        this.db.close();
+        this.db = null;
+        this.initialized = false;
     }
 }
 

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -1178,16 +1178,65 @@ class ModelDatabase {
     }
 
     /**
-     * Clear all data
+     * Snapshot local speed telemetry keyed by model_id + tag so it can survive
+     * a force sync that recreates variant row ids.
+     */
+    snapshotSpeedBenchmarks() {
+        return this.all(`
+            SELECT v.model_id, v.tag, b.hardware_fingerprint, b.tokens_per_second,
+                   b.time_to_first_token, b.memory_used_gb, b.backend, b.created_at
+            FROM benchmarks b
+            JOIN variants v ON v.id = b.variant_id
+        `);
+    }
+
+    /**
+     * Reattach previously measured speed benchmarks to newly upserted variants.
+     * Replace, do not append: SQLite FKs are off by default so DELETE FROM
+     * variants does not cascade, and leftover rows would otherwise duplicate.
+     */
+    restoreSpeedBenchmarks(rows) {
+        this.run(`DELETE FROM benchmarks`);
+        if (!rows || rows.length === 0) return;
+
+        const insert = `
+            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second,
+                time_to_first_token, memory_used_gb, backend, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        `;
+
+        for (const row of rows) {
+            const variant = this.get(
+                `SELECT id FROM variants WHERE model_id = ? AND tag = ?`,
+                [row.model_id, row.tag]
+            );
+            if (!variant) continue;
+            this.run(insert, [
+                variant.id,
+                row.hardware_fingerprint,
+                row.tokens_per_second,
+                row.time_to_first_token,
+                row.memory_used_gb,
+                row.backend,
+                row.created_at || null
+            ]);
+        }
+    }
+
+    /**
+     * Clear catalog data. Local speed benchmarks are snapshotted by callers
+     * that recreate variants (variant_id is an autoincrement FK). Drop leftover
+     * benchmark rows here because SQLite FKs are off by default, so DELETE FROM
+     * variants does not cascade.
      */
     clear() {
         // The registry's Ollama source is derived from the local Ollama catalog.
         // Clear only that source so a classic Ollama sync does not erase HF/GPT4All data.
         this.clearRegistrySource('ollama');
-        this.run(`DELETE FROM benchmarks`);
         this.run(`DELETE FROM variants`);
         this.run(`DELETE FROM models`);
         this.run(`DELETE FROM sync_meta`);
+        this.run(`DELETE FROM benchmarks`);
     }
 
     /**

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -65,6 +65,7 @@ class ModelDatabase {
         this.useBetterSqlite = false;
 
         this.createSchema();
+        this.migrateSpeedBenchmarks();
         this.initialized = true;
         if (!this.disableRegistrySeedImport) {
             await this.seedRegistryFromPackagedSnapshotIfNeeded();
@@ -113,14 +114,16 @@ class ModelDatabase {
             -- Benchmarks table (real performance data per hardware)
             CREATE TABLE IF NOT EXISTS benchmarks (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                variant_id INTEGER NOT NULL,
+                variant_id INTEGER,
+                model_id TEXT,
+                tag TEXT,
                 hardware_fingerprint TEXT NOT NULL,
                 tokens_per_second REAL,
                 time_to_first_token REAL,
                 memory_used_gb REAL,
                 backend TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE CASCADE
+                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE SET NULL
             );
 
             -- Registry sources for multi-hub model discovery (Hugging Face,
@@ -239,6 +242,47 @@ class ModelDatabase {
         } else {
             this.db.run(schema);
             this.saveToFile();
+        }
+    }
+
+    migrateSpeedBenchmarks() {
+        if (this.all('PRAGMA table_info(benchmarks)').some((column) => column.name === 'model_id')) return;
+        // Preserve the original measurement ids/timestamps and backfill stable
+        // identities before any catalog refresh can replace variant row ids.
+        this.beginBatch();
+        try {
+            this.db.exec(`
+                SAVEPOINT migrate_speed_benchmarks;
+                CREATE TABLE benchmarks_stable (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    variant_id INTEGER,
+                    model_id TEXT,
+                    tag TEXT,
+                    hardware_fingerprint TEXT NOT NULL,
+                    tokens_per_second REAL,
+                    time_to_first_token REAL,
+                    memory_used_gb REAL,
+                    backend TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE SET NULL
+                );
+                INSERT INTO benchmarks_stable
+                SELECT b.id, v.id, v.model_id, v.tag, b.hardware_fingerprint,
+                       b.tokens_per_second, b.time_to_first_token, b.memory_used_gb,
+                       b.backend, b.created_at
+                FROM benchmarks b LEFT JOIN variants v ON v.id = b.variant_id;
+                DROP TABLE benchmarks;
+                ALTER TABLE benchmarks_stable RENAME TO benchmarks;
+                CREATE INDEX idx_benchmarks_hardware ON benchmarks(hardware_fingerprint);
+                CREATE INDEX idx_benchmarks_variant ON benchmarks(variant_id);
+                RELEASE migrate_speed_benchmarks;
+            `);
+            this._pendingSave = true;
+        } catch (error) {
+            this.db.exec('ROLLBACK TO migrate_speed_benchmarks; RELEASE migrate_speed_benchmarks;');
+            throw error;
+        } finally {
+            this.endBatch();
         }
     }
 
@@ -446,13 +490,17 @@ class ModelDatabase {
      * Add benchmark result
      */
     addBenchmark(benchmark) {
+        const variant = this.get('SELECT model_id, tag FROM variants WHERE id = ?', [benchmark.variant_id]);
+        if (!variant) throw new Error('Cannot record a benchmark for an unknown variant');
         const sql = `
-            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second, time_to_first_token, memory_used_gb, backend)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO benchmarks (variant_id, model_id, tag, hardware_fingerprint, tokens_per_second, time_to_first_token, memory_used_gb, backend)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         `;
 
         this.run(sql, [
             benchmark.variant_id,
+            variant.model_id,
+            variant.tag,
             benchmark.hardware_fingerprint,
             benchmark.tokens_per_second,
             benchmark.time_to_first_token,
@@ -1177,66 +1225,22 @@ class ModelDatabase {
         };
     }
 
-    /**
-     * Snapshot local speed telemetry keyed by model_id + tag so it can survive
-     * a force sync that recreates variant row ids.
-     */
-    snapshotSpeedBenchmarks() {
-        return this.all(`
-            SELECT v.model_id, v.tag, b.hardware_fingerprint, b.tokens_per_second,
-                   b.time_to_first_token, b.memory_used_gb, b.backend, b.created_at
-            FROM benchmarks b
-            JOIN variants v ON v.id = b.variant_id
-        `);
+    /** Reattach persisted telemetry after a catalog rebuild. Missing models keep
+     * their measurements, ready for a later sync that brings the tag back. */
+    reattachSpeedBenchmarks() {
+        this.run(`UPDATE benchmarks SET variant_id = (
+            SELECT v.id FROM variants v
+            WHERE v.model_id = benchmarks.model_id AND v.tag = benchmarks.tag
+        )`);
     }
 
-    /**
-     * Reattach previously measured speed benchmarks to newly upserted variants.
-     * Replace, do not append: SQLite FKs are off by default so DELETE FROM
-     * variants does not cascade, and leftover rows would otherwise duplicate.
-     */
-    restoreSpeedBenchmarks(rows) {
-        this.run(`DELETE FROM benchmarks`);
-        if (!rows || rows.length === 0) return;
-
-        const insert = `
-            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second,
-                time_to_first_token, memory_used_gb, backend, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-        `;
-
-        for (const row of rows) {
-            const variant = this.get(
-                `SELECT id FROM variants WHERE model_id = ? AND tag = ?`,
-                [row.model_id, row.tag]
-            );
-            if (!variant) continue;
-            this.run(insert, [
-                variant.id,
-                row.hardware_fingerprint,
-                row.tokens_per_second,
-                row.time_to_first_token,
-                row.memory_used_gb,
-                row.backend,
-                row.created_at || null
-            ]);
-        }
-    }
-
-    /**
-     * Clear catalog data. Local speed benchmarks are snapshotted by callers
-     * that recreate variants (variant_id is an autoincrement FK). Drop leftover
-     * benchmark rows here because SQLite FKs are off by default, so DELETE FROM
-     * variants does not cascade.
-     */
+    /** Clear catalog data while preserving local measurements and their keys. */
     clear() {
-        // The registry's Ollama source is derived from the local Ollama catalog.
-        // Clear only that source so a classic Ollama sync does not erase HF/GPT4All data.
         this.clearRegistrySource('ollama');
-        this.run(`DELETE FROM variants`);
-        this.run(`DELETE FROM models`);
-        this.run(`DELETE FROM sync_meta`);
-        this.run(`DELETE FROM benchmarks`);
+        this.run('UPDATE benchmarks SET variant_id = NULL');
+        this.run('DELETE FROM variants');
+        this.run('DELETE FROM models');
+        this.run('DELETE FROM sync_meta');
     }
 
     /**

--- a/src/data/registry-ingestors.js
+++ b/src/data/registry-ingestors.js
@@ -25,6 +25,22 @@ const SOURCE_DEFINITIONS = {
 const HUGGING_FACE_MODEL_API = 'https://huggingface.co/api/models';
 const GPT4ALL_MODELS_URL = 'https://gpt4all.io/models/models3.json';
 
+// A weight-file extension alone also matches diffusion models and asset bundles.
+// Require an explicit language/vision-language task, including older Hub tags.
+const LANGUAGE_MODEL_TASKS = new Set([
+    'text-generation', 'text2text-generation', 'conversational',
+    'image-text-to-text', 'image-to-text', 'visual-question-answering',
+    'document-question-answering', 'feature-extraction', 'sentence-similarity'
+]);
+
+function isSupportedHuggingFaceModel(model = {}) {
+    const library = String(model.library_name || '').toLowerCase();
+    if (/^(diffusers|diffusion-single-file|timm|peft|adapter-transformers)$/.test(library)) return false;
+    const pipeline = String(model.pipeline_tag || '').toLowerCase();
+    if (pipeline) return LANGUAGE_MODEL_TASKS.has(pipeline);
+    return toArray(model.tags).some((tag) => LANGUAGE_MODEL_TASKS.has(String(tag).toLowerCase()));
+}
+
 function extractNextLink(linkHeader = '') {
     const links = String(linkHeader || '').split(',');
     for (const link of links) {
@@ -298,7 +314,7 @@ function buildHuggingFaceDownloadUrl(repoId, filename, revision = 'main') {
 
 function normalizeHuggingFaceModel(model) {
     const repoId = model.id || model.modelId || model.model_id;
-    if (!repoId) return null;
+    if (!repoId || !isSupportedHuggingFaceModel(model)) return null;
 
     const namespace = repoId.includes('/') ? repoId.split('/')[0] : '';
     const tags = toArray(model.tags);
@@ -758,6 +774,7 @@ module.exports = {
     RegistryIngestor,
     SOURCE_DEFINITIONS,
     normalizeHuggingFaceModel,
+    isSupportedHuggingFaceModel,
     normalizeGpt4AllEntry,
     normalizeOllamaRows,
     inferFormat,

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -1,4 +1,5 @@
 const ModelDatabase = require('./model-database');
+const { isSupportedHuggingFaceModel } = require('./registry-ingestors');
 const DeterministicModelSelector = require('../models/deterministic-selector');
 const { applyCpuOnlyOverride } = require('../hardware/cpu-only');
 const { runtimeSupportedOnHardware } = require('../runtime/runtime-support');
@@ -117,6 +118,12 @@ function choosePreferredRuntime(runtimeSupport = [], format = '', sourceId = '')
 }
 
 function artifactToSelectorModel(row) {
+    // Apply the same rule to existing user databases and the packaged snapshot,
+    // so rejected repositories disappear from recommendations without a resync.
+    if (row.source_id === 'huggingface' && !isSupportedHuggingFaceModel({
+        ...(row.repo_metadata || {}),
+        tags: [...toArray(row.repo_tags), ...toArray(row.repo_tasks), ...toArray(row.tasks)]
+    })) return null;
     const shardedFile = row.source_id === 'huggingface' && isShardedWeightFile(row.filename || row.artifact_name);
     const identifier = shardedFile
         ? (row.canonical_model_id || row.repo_id)

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -590,7 +590,9 @@ class RegistryRecommender {
                     bestModels: selection.result.candidates.map((candidate) => this.selector.mapCandidateToLegacyFormat(candidate)),
                     totalEvaluated: selection.result.total_evaluated,
                     totalArtifacts: selection.rows.length,
-                    totalCandidates: selection.modelPool.length,
+                    // Public category headers use this field as "evaluated".
+                    // The unfiltered catalog pool is shared by every category.
+                    totalCandidates: selection.result.total_evaluated,
                     category: this.selector.getCategoryInfo(category)
                 };
             } catch (error) {
@@ -641,6 +643,7 @@ class RegistryRecommender {
         const budget = isUnified ? usableMem : (vram || usableMem);
         const filtered = this.selector.filterByCategory(modelPool, category, { includeUncensored });
         const candidates = [];
+        let totalEvaluated = 0;
 
         for (const model of filtered) {
             const preferredRuntime = model.preferredRuntime || choosePreferredRuntime(
@@ -656,6 +659,7 @@ class RegistryRecommender {
                 runtimeSupportedOnHardware(candidateRuntime, normalizedHardware)
             );
             if (!runtime) continue;
+            totalEvaluated += 1;
             const candidate = this.selector.evaluateModel(
                 model,
                 normalizedHardware,
@@ -678,7 +682,7 @@ class RegistryRecommender {
             // Return a wide sorted window; selectCategory collapses variants and
             // applies source diversity before trimming to the caller's limit.
             candidates: candidates.slice(0, Math.max(limit, 2000)),
-            total_evaluated: filtered.length,
+            total_evaluated: totalEvaluated,
             timestamp: new Date().toISOString()
         };
     }

--- a/src/data/sync-manager.js
+++ b/src/data/sync-manager.js
@@ -52,7 +52,11 @@ class SyncManager {
         // times, turning the sync into O(n^2) disk I/O.
         this.db.beginBatch();
         try {
-            // Clear existing data
+            // Keep locally measured speed telemetry across force sync.
+            const speedBenchmarks = this.db.snapshotSpeedBenchmarks();
+
+            // Clear existing catalog data (variants/models). Benchmarks are
+            // re-keyed onto new variant ids after upsert.
             this.db.clear();
 
             // Scrape all models
@@ -62,6 +66,8 @@ class SyncManager {
                     this.db.upsertVariant(variant);
                 }
             });
+
+            this.db.restoreSpeedBenchmarks(speedBenchmarks);
 
             // Update sync timestamp
             this.db.setLastSync(new Date().toISOString());

--- a/src/data/sync-manager.js
+++ b/src/data/sync-manager.js
@@ -52,11 +52,9 @@ class SyncManager {
         // times, turning the sync into O(n^2) disk I/O.
         this.db.beginBatch();
         try {
-            // Keep locally measured speed telemetry across force sync.
-            const speedBenchmarks = this.db.snapshotSpeedBenchmarks();
-
-            // Clear existing catalog data (variants/models). Benchmarks are
-            // re-keyed onto new variant ids after upsert.
+            this.db.run('SAVEPOINT full_sync');
+            // Stable model/tag keys keep telemetry even when a model temporarily
+            // disappears from the catalog. Roll back failed refreshes as a unit.
             this.db.clear();
 
             // Scrape all models
@@ -67,10 +65,15 @@ class SyncManager {
                 }
             });
 
-            this.db.restoreSpeedBenchmarks(speedBenchmarks);
+            this.db.reattachSpeedBenchmarks();
 
             // Update sync timestamp
             this.db.setLastSync(new Date().toISOString());
+            this.db.run('RELEASE full_sync');
+        } catch (error) {
+            this.db.run('ROLLBACK TO full_sync');
+            this.db.run('RELEASE full_sync');
+            throw error;
         } finally {
             this.db.endBatch();
         }

--- a/src/hardware/backends/apple-silicon.js
+++ b/src/hardware/backends/apple-silicon.js
@@ -5,11 +5,16 @@
  */
 
 const { execSync } = require('child_process');
+const { execFileAsync } = require('../probe-exec');
 
 class AppleSiliconDetector {
     constructor() {
         this.cache = null;
         this.isSupported = process.platform === 'darwin' && process.arch === 'arm64';
+    }
+
+    usesOverriddenDetect() {
+        return this.detect !== AppleSiliconDetector.prototype.detect;
     }
 
     /**
@@ -26,6 +31,28 @@ class AppleSiliconDetector {
 
         try {
             const info = this.getChipInfo();
+            this.cache = info;
+            return info;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async detectAsync() {
+        if (this.usesOverriddenDetect()) {
+            return this.detect();
+        }
+
+        if (!this.isSupported) {
+            return null;
+        }
+
+        if (this.cache) {
+            return this.cache;
+        }
+
+        try {
+            const info = await this.getChipInfoAsync();
             this.cache = info;
             return info;
         } catch (error) {
@@ -142,6 +169,108 @@ class AppleSiliconDetector {
         result.speedCoefficient = this.calculateSpeedCoefficient(result);
         result.memory.bandwidth = this.estimateMemoryBandwidth(result.variant, result.generation);
 
+        return result;
+    }
+
+    async getChipInfoAsync() {
+        const result = {
+            chip: null,
+            variant: null,
+            generation: null,
+            cores: {
+                performance: 0,
+                efficiency: 0,
+                total: 0
+            },
+            gpu: {
+                cores: 0,
+                model: null
+            },
+            neuralEngine: {
+                cores: 0
+            },
+            memory: {
+                unified: 0,
+                bandwidth: null
+            },
+            capabilities: {
+                metal: true,
+                metalVersion: null,
+                fp16: true,
+                int8: true,
+                amx: true
+            },
+            backend: 'metal',
+            speedCoefficient: 0
+        };
+
+        const sysctl = async (key) => {
+            const out = await execFileAsync('sysctl', ['-n', key], { encoding: 'utf8', timeout: 5000 });
+            return String(out).trim();
+        };
+
+        try {
+            const [brand, ncpu, perf, eff, memBytes, gpuInfo] = await Promise.all([
+                sysctl('machdep.cpu.brand_string').catch(() => ''),
+                sysctl('hw.ncpu').catch(() => ''),
+                sysctl('hw.perflevel0.logicalcpu').catch(() => ''),
+                sysctl('hw.perflevel1.logicalcpu').catch(() => ''),
+                sysctl('hw.memsize').catch(() => ''),
+                execFileAsync('system_profiler', ['SPDisplaysDataType', '-json'], {
+                    encoding: 'utf8',
+                    timeout: 5000
+                }).catch(() => '')
+            ]);
+
+            if (brand) {
+                result.chip = brand;
+                const parsed = this.parseChipBrand(brand);
+                result.variant = parsed.variant;
+                result.generation = parsed.generation;
+            }
+
+            result.cores.total = parseInt(ncpu, 10) || require('os').cpus().length;
+            result.cores.performance = parseInt(perf, 10) || Math.ceil(result.cores.total / 2);
+            result.cores.efficiency = parseInt(eff, 10) || Math.floor(result.cores.total / 2);
+
+            const memParsed = parseInt(memBytes, 10);
+            result.memory.unified = Number.isFinite(memParsed)
+                ? Math.round(memParsed / (1024 ** 3))
+                : Math.round(require('os').totalmem() / (1024 ** 3));
+
+            try {
+                const parsedGpu = gpuInfo ? JSON.parse(gpuInfo) : {};
+                const displays = parsedGpu.SPDisplaysDataType || [];
+                if (displays.length > 0) {
+                    const gpu = displays[0];
+                    result.gpu.model = gpu.sppci_model || result.chip;
+                    const coreMatch = gpu.sppci_cores?.match(/(\d+)/);
+                    result.gpu.cores = coreMatch
+                        ? parseInt(coreMatch[1], 10)
+                        : this.estimateGPUCores(result.variant, result.generation);
+                    const metal = JSON.stringify(gpu);
+                    const match = metal.match(/Metal\s*([\d.]+|Family)/i);
+                    result.capabilities.metalVersion = match ? match[1] : '3';
+                } else {
+                    result.gpu.cores = this.estimateGPUCores(result.variant, result.generation);
+                    result.gpu.model = result.chip;
+                    result.capabilities.metalVersion = '3';
+                }
+            } catch (e) {
+                result.gpu.cores = this.estimateGPUCores(result.variant, result.generation);
+                result.gpu.model = result.chip;
+                result.capabilities.metalVersion = '3';
+            }
+        } catch (e) {
+            result.cores.total = require('os').cpus().length;
+            result.memory.unified = Math.round(require('os').totalmem() / (1024 ** 3));
+            result.gpu.cores = this.estimateGPUCores(result.variant, result.generation);
+            result.gpu.model = result.chip;
+            result.capabilities.metalVersion = '3';
+        }
+
+        result.speedCoefficient = this.calculateSpeedCoefficient(result);
+        result.memory.bandwidth = this.estimateMemoryBandwidth(result.variant, result.generation);
         return result;
     }
 

--- a/src/hardware/backends/cpu-detector.js
+++ b/src/hardware/backends/cpu-detector.js
@@ -8,10 +8,15 @@ const childProcess = require('child_process');
 const os = require('os');
 const fs = require('fs');
 const { normalizePlatform } = require('../../utils/platform');
+const { execFileAsync, execCommandAsync } = require('../probe-exec');
 
 class CPUDetector {
     constructor() {
         this.cache = null;
+    }
+
+    usesOverriddenDetect() {
+        return this.detect !== CPUDetector.prototype.detect;
     }
 
     /**
@@ -24,6 +29,24 @@ class CPUDetector {
 
         try {
             const info = this.getCPUInfo();
+            this.cache = info;
+            return info;
+        } catch (error) {
+            return this.getFallbackInfo();
+        }
+    }
+
+    async detectAsync() {
+        if (this.usesOverriddenDetect()) {
+            return this.detect();
+        }
+
+        if (this.cache) {
+            return this.cache;
+        }
+
+        try {
+            const info = await this.getCPUInfoAsync();
             this.cache = info;
             return info;
         } catch (error) {
@@ -69,6 +92,43 @@ class CPUDetector {
         return result;
     }
 
+    async getCPUInfoAsync() {
+        const cpus = os.cpus();
+        const cpu = cpus[0] || {};
+        const [physical, maxFreq, cache, capabilities] = await Promise.all([
+            this.getPhysicalCoresAsync(),
+            this.getMaxFrequencyAsync(),
+            this.getCacheInfoAsync(),
+            this.getCapabilitiesAsync()
+        ]);
+
+        const result = {
+            brand: cpu.model || 'Unknown CPU',
+            vendor: this.detectVendor(cpu.model),
+            cores: {
+                physical,
+                logical: cpus.length,
+                performance: 0,
+                efficiency: 0
+            },
+            frequency: {
+                base: cpu.speed || 0,
+                max: maxFreq
+            },
+            cache,
+            capabilities,
+            architecture: process.arch,
+            backend: 'cpu',
+            speedCoefficient: 0
+        };
+
+        const hybrid = this.detectHybridCores(result.brand);
+        result.cores.performance = hybrid.performance;
+        result.cores.efficiency = hybrid.efficiency;
+        result.speedCoefficient = this.calculateSpeedCoefficient(result);
+        return result;
+    }
+
     /**
      * Detect CPU vendor
      */
@@ -111,6 +171,30 @@ class CPUDetector {
         return os.cpus().length;
     }
 
+    async getPhysicalCoresAsync() {
+        const platform = normalizePlatform();
+
+        try {
+            if (platform === 'darwin') {
+                const out = await execFileAsync('sysctl', ['-n', 'hw.physicalcpu'], {
+                    encoding: 'utf8',
+                    timeout: 5000
+                });
+                return parseInt(String(out).trim(), 10);
+            }
+            if (platform === 'linux') {
+                return this.getPhysicalCores();
+            }
+            if (platform === 'win32') {
+                const physicalCores = await this.getWindowsPhysicalCoreCountAsync();
+                return physicalCores || os.cpus().length;
+            }
+        } catch (e) {
+            return os.cpus().length;
+        }
+        return os.cpus().length;
+    }
+
     /**
      * Get maximum CPU frequency
      */
@@ -136,6 +220,19 @@ class CPUDetector {
             return os.cpus()[0]?.speed || 0;
         }
         return 0;
+    }
+
+    async getMaxFrequencyAsync() {
+        const platform = normalizePlatform();
+        if (platform !== 'win32') {
+            return this.getMaxFrequency();
+        }
+        try {
+            const maxClock = await this.getWindowsMaxClockSpeedAsync();
+            return maxClock || (os.cpus()[0]?.speed || 0);
+        } catch (e) {
+            return os.cpus()[0]?.speed || 0;
+        }
     }
 
     /**
@@ -230,6 +327,50 @@ class CPUDetector {
         return value && value > 0 ? value : null;
     }
 
+    async runCommandAsync(command) {
+        if (typeof this.runCommand === 'function' && this.runCommand !== CPUDetector.prototype.runCommand) {
+            return this.runCommand(command);
+        }
+        return execCommandAsync(command, {
+            encoding: 'utf8',
+            timeout: 5000,
+            shell: true
+        });
+    }
+
+    async queryWindowsNumericAsync(commands) {
+        for (const command of commands) {
+            try {
+                const output = await this.runCommandAsync(command);
+                const parsed = this.extractFirstInteger(output);
+                if (parsed !== null) {
+                    return parsed;
+                }
+            } catch (e) {
+                continue;
+            }
+        }
+        return null;
+    }
+
+    async getWindowsPhysicalCoreCountAsync() {
+        const value = await this.queryWindowsNumericAsync([
+            'wmic cpu get NumberOfCores /value',
+            'powershell -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Processor | Measure-Object -Property NumberOfCores -Sum).Sum"',
+            'pwsh -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Processor | Measure-Object -Property NumberOfCores -Sum).Sum"'
+        ]);
+        return value && value > 0 ? value : null;
+    }
+
+    async getWindowsMaxClockSpeedAsync() {
+        const value = await this.queryWindowsNumericAsync([
+            'wmic cpu get MaxClockSpeed /value',
+            'powershell -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Processor | Measure-Object -Property MaxClockSpeed -Maximum).Maximum"',
+            'pwsh -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Processor | Measure-Object -Property MaxClockSpeed -Maximum).Maximum"'
+        ]);
+        return value && value > 0 ? value : null;
+    }
+
     /**
      * Get CPU cache information
      */
@@ -279,6 +420,35 @@ class CPUDetector {
         }
 
         return cache;
+    }
+
+    async getCacheInfoAsync() {
+        const cache = {
+            l1d: 0,
+            l1i: 0,
+            l2: 0,
+            l3: 0
+        };
+        const platform = normalizePlatform();
+
+        try {
+            if (platform === 'darwin') {
+                const [l1d, l1i, l2, l3] = await Promise.all([
+                    execFileAsync('sysctl', ['-n', 'hw.l1dcachesize'], { encoding: 'utf8', timeout: 5000 }).catch(() => '0'),
+                    execFileAsync('sysctl', ['-n', 'hw.l1icachesize'], { encoding: 'utf8', timeout: 5000 }).catch(() => '0'),
+                    execFileAsync('sysctl', ['-n', 'hw.l2cachesize'], { encoding: 'utf8', timeout: 5000 }).catch(() => '0'),
+                    execFileAsync('sysctl', ['-n', 'hw.l3cachesize'], { encoding: 'utf8', timeout: 5000 }).catch(() => '0')
+                ]);
+                cache.l1d = parseInt(String(l1d), 10) / 1024 || 0;
+                cache.l1i = parseInt(String(l1i), 10) / 1024 || 0;
+                cache.l2 = parseInt(String(l2), 10) / 1024 / 1024 || 0;
+                cache.l3 = parseInt(String(l3), 10) / 1024 / 1024 || 0;
+                return cache;
+            }
+            return this.getCacheInfo();
+        } catch (e) {
+            return cache;
+        }
     }
 
     /**
@@ -409,6 +579,65 @@ class CPUDetector {
         }
 
         // Determine best SIMD level
+        if (caps.amx) caps.bestSimd = 'AMX';
+        else if (caps.avx512) caps.bestSimd = 'AVX512';
+        else if (caps.avx2) caps.bestSimd = 'AVX2';
+        else if (caps.avx) caps.bestSimd = 'AVX';
+        else if (caps.neon) caps.bestSimd = 'NEON';
+        else if (caps.sse4_2) caps.bestSimd = 'SSE4.2';
+        else if (caps.sse2) caps.bestSimd = 'SSE2';
+
+        return caps;
+    }
+
+    async getCapabilitiesAsync() {
+        const platform = normalizePlatform();
+        if (platform !== 'darwin' || process.arch === 'arm64') {
+            return this.getCapabilities();
+        }
+
+        const caps = {
+            sse: false,
+            sse2: false,
+            sse3: false,
+            ssse3: false,
+            sse4_1: false,
+            sse4_2: false,
+            avx: false,
+            avx2: false,
+            avx512: false,
+            avx512_vnni: false,
+            amx: false,
+            fma: false,
+            f16c: false,
+            neon: false,
+            sve: false,
+            dotprod: false,
+            bestSimd: 'none'
+        };
+
+        try {
+            const [featuresRaw, leafRaw] = await Promise.all([
+                execFileAsync('sysctl', ['-n', 'machdep.cpu.features'], { encoding: 'utf8', timeout: 5000 }),
+                execFileAsync('sysctl', ['-n', 'machdep.cpu.leaf7_features'], { encoding: 'utf8', timeout: 5000 })
+            ]);
+            const features = String(featuresRaw).toLowerCase();
+            const leafFeatures = String(leafRaw).toLowerCase();
+            caps.sse = features.includes('sse');
+            caps.sse2 = features.includes('sse2');
+            caps.sse3 = features.includes('sse3');
+            caps.ssse3 = features.includes('ssse3');
+            caps.sse4_1 = features.includes('sse4.1');
+            caps.sse4_2 = features.includes('sse4.2');
+            caps.avx = features.includes('avx1.0') || features.includes('avx ');
+            caps.avx2 = leafFeatures.includes('avx2');
+            caps.fma = features.includes('fma');
+            caps.f16c = leafFeatures.includes('f16c');
+            caps.avx512 = leafFeatures.includes('avx512');
+        } catch (e) {
+            caps.sse = caps.sse2 = true;
+        }
+
         if (caps.amx) caps.bestSimd = 'AMX';
         else if (caps.avx512) caps.bestSimd = 'AVX512';
         else if (caps.avx2) caps.bestSimd = 'AVX2';

--- a/src/hardware/backends/cuda-detector.js
+++ b/src/hardware/backends/cuda-detector.js
@@ -6,7 +6,8 @@
 
 const fs = require('fs');
 const os = require('os');
-const { execSync, exec } = require('child_process');
+const { execSync } = require('child_process');
+const { execCommandAsync } = require('../probe-exec');
 
 class CUDADetector {
     constructor() {
@@ -17,6 +18,18 @@ class CUDADetector {
 
     execCommand(command, options = {}) {
         return execSync(command, options);
+    }
+
+    execCommandAsync(command, options = {}) {
+        return execCommandAsync(command, options);
+    }
+
+    usesOverriddenDetect() {
+        return this.detect !== CUDADetector.prototype.detect;
+    }
+
+    usesOverriddenAvailability() {
+        return this.checkAvailability !== CUDADetector.prototype.checkAvailability;
     }
 
     /**
@@ -45,12 +58,50 @@ class CUDADetector {
         return this.isAvailable;
     }
 
+    async checkAvailabilityAsync() {
+        if (this.usesOverriddenAvailability()) {
+            return this.checkAvailability();
+        }
+
+        if (this.isAvailable !== null) {
+            return this.isAvailable;
+        }
+
+        if (await this.hasNvidiaSMIAsync()) {
+            this.isAvailable = true;
+            this.detectionMode = 'nvidia-smi';
+            return this.isAvailable;
+        }
+
+        if (this.isJetsonPlatform() && await this.hasJetsonCudaSupportAsync()) {
+            this.isAvailable = true;
+            this.detectionMode = 'jetson';
+            return this.isAvailable;
+        }
+
+        this.isAvailable = false;
+        this.detectionMode = null;
+        return this.isAvailable;
+    }
+
     hasNvidiaSMI() {
         try {
             this.execCommand('nvidia-smi --version', {
                 encoding: 'utf8',
                 timeout: 5000,
                 stdio: ['pipe', 'pipe', 'pipe']
+            });
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    async hasNvidiaSMIAsync() {
+        try {
+            await this.execCommandAsync('nvidia-smi --version', {
+                encoding: 'utf8',
+                timeout: 5000
             });
             return true;
         } catch (e) {
@@ -157,6 +208,33 @@ class CUDADetector {
         }
     }
 
+    async hasJetsonCudaSupportAsync() {
+        const runtimeHints = [
+            '/usr/local/cuda',
+            '/usr/bin/tegrastats',
+            '/usr/sbin/nvpmodel',
+            '/usr/lib/aarch64-linux-gnu/tegra',
+            '/etc/nv_tegra_release',
+            '/dev/nvhost-gpu',
+            '/dev/nvmap',
+            '/proc/driver/nvidia/version'
+        ];
+
+        if (runtimeHints.some((hintPath) => fs.existsSync(hintPath))) {
+            return true;
+        }
+
+        try {
+            await this.execCommandAsync('nvcc --version', {
+                encoding: 'utf8',
+                timeout: 5000
+            });
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
     /**
      * Detect all NVIDIA GPUs and their capabilities
      */
@@ -173,6 +251,35 @@ class CUDADetector {
             const info = this.detectionMode === 'jetson'
                 ? this.getJetsonGPUInfo()
                 : this.getGPUInfo();
+
+            if (!info || !Array.isArray(info.gpus) || info.gpus.length === 0) {
+                return null;
+            }
+
+            this.cache = info;
+            return info;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async detectAsync() {
+        if (this.usesOverriddenDetect()) {
+            return this.detect();
+        }
+
+        if (!(await this.checkAvailabilityAsync())) {
+            return null;
+        }
+
+        if (this.cache) {
+            return this.cache;
+        }
+
+        try {
+            const info = this.detectionMode === 'jetson'
+                ? await this.getJetsonGPUInfoAsync()
+                : await this.getGPUInfoAsync();
 
             if (!info || !Array.isArray(info.gpus) || info.gpus.length === 0) {
                 return null;
@@ -351,6 +458,156 @@ class CUDADetector {
         return result;
     }
 
+    async getGPUInfoAsync() {
+        const result = {
+            gpus: [],
+            driver: null,
+            cuda: null,
+            totalVRAM: 0,
+            backend: 'cuda',
+            isMultiGPU: false,
+            speedCoefficient: 0
+        };
+
+        try {
+            const [versionOut, banner] = await Promise.all([
+                this.execCommandAsync('nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits', {
+                    encoding: 'utf8',
+                    timeout: 5000
+                }),
+                this.execCommandAsync('nvidia-smi', {
+                    encoding: 'utf8',
+                    timeout: 5000
+                })
+            ]);
+            result.driver = String(versionOut).trim().split('\n')[0];
+            const header = String(banner).split('\n').slice(0, 3).join('\n');
+            const cudaMatch = header.match(/CUDA Version:\s*([\d.]+)/);
+            if (cudaMatch) {
+                result.cuda = cudaMatch[1];
+            }
+        } catch (e) {
+            // Continue without version info
+        }
+
+        try {
+            const query = [
+                'index',
+                'name',
+                'uuid',
+                'memory.total',
+                'memory.free',
+                'memory.used',
+                'compute_mode',
+                'pcie.link.gen.current',
+                'pcie.link.width.current',
+                'power.draw',
+                'power.limit',
+                'temperature.gpu',
+                'utilization.gpu',
+                'utilization.memory',
+                'clocks.current.sm',
+                'clocks.max.sm'
+            ].join(',');
+
+            const gpuData = (await this.execCommandAsync(
+                `nvidia-smi --query-gpu=${query} --format=csv,noheader,nounits`,
+                { encoding: 'utf8', timeout: 10000 }
+            )).trim();
+
+            const lines = gpuData.split('\n');
+            const toMB = (value) => {
+                const n = parseInt(value, 10);
+                return Number.isFinite(n) ? n : 0;
+            };
+            const toGB = (value) => {
+                const mb = toMB(value);
+                return mb > 0 ? Math.round(mb / 1024) : 0;
+            };
+            const toInt = (value) => {
+                const n = parseInt(value, 10);
+                return Number.isFinite(n) ? n : 0;
+            };
+            const toFloat = (value) => {
+                const n = parseFloat(value);
+                return Number.isFinite(n) ? n : 0;
+            };
+
+            for (const line of lines) {
+                if (!line || !line.trim()) continue;
+                const parts = line.split(/\s*,\s*/).map(p => p.trim());
+                if (parts.length < 4) continue;
+                const memTotalMB = toMB(parts[3]);
+                const gpu = {
+                    index: toInt(parts[0]),
+                    name: parts[1] || 'Unknown NVIDIA GPU',
+                    uuid: parts[2] || null,
+                    memory: {
+                        total: toGB(parts[3]),
+                        free: toGB(parts[4]),
+                        used: toGB(parts[5])
+                    },
+                    computeMode: parts[6] || 'Default',
+                    pcie: {
+                        generation: toInt(parts[7]),
+                        width: toInt(parts[8])
+                    },
+                    power: {
+                        draw: toFloat(parts[9]),
+                        limit: toFloat(parts[10])
+                    },
+                    temperature: toInt(parts[11]),
+                    utilization: {
+                        gpu: toInt(parts[12]),
+                        memory: toInt(parts[13])
+                    },
+                    clocks: {
+                        current: toInt(parts[14]),
+                        max: toInt(parts[15])
+                    },
+                    capabilities: this.getGPUCapabilities(parts[1]),
+                    speedCoefficient: this.calculateSpeedCoefficient(parts[1], memTotalMB)
+                };
+                result.gpus.push(gpu);
+                result.totalVRAM += gpu.memory.total;
+            }
+        } catch (e) {
+            try {
+                const simpleQuery = (await this.execCommandAsync(
+                    'nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits',
+                    { encoding: 'utf8', timeout: 5000 }
+                )).trim();
+
+                const lines = simpleQuery.split('\n');
+                for (let i = 0; i < lines.length; i++) {
+                    if (!lines[i] || !lines[i].trim()) continue;
+                    const [name, memMB] = lines[i].split(/\s*,\s*/).map(p => p.trim());
+                    const parsedMB = parseInt(memMB, 10);
+                    const memMBSafe = Number.isFinite(parsedMB) ? parsedMB : 0;
+                    const memGB = memMBSafe > 0 ? Math.round(memMBSafe / 1024) : 0;
+
+                    result.gpus.push({
+                        index: i,
+                        name: name || 'NVIDIA GPU',
+                        memory: { total: memGB, free: memGB, used: 0 },
+                        capabilities: this.getGPUCapabilities(name),
+                        speedCoefficient: this.calculateSpeedCoefficient(name, memMBSafe)
+                    });
+                    result.totalVRAM += memGB;
+                }
+            } catch (e2) {
+                return null;
+            }
+        }
+
+        result.isMultiGPU = result.gpus.length > 1;
+        result.speedCoefficient = result.gpus.length > 0
+            ? Math.max(...result.gpus.map(g => g.speedCoefficient))
+            : 0;
+
+        return result;
+    }
+
     getJetsonGPUInfo() {
         const modelRaw = this.readJetsonModel();
         const model = this.normalizeJetsonModel(modelRaw);
@@ -433,6 +690,48 @@ class CUDADetector {
         return 'NVIDIA Jetson (CUDA)';
     }
 
+    getJetsonGPUInfoAsync() {
+        return Promise.resolve().then(async () => {
+            const modelRaw = this.readJetsonModel();
+            const model = this.normalizeJetsonModel(modelRaw);
+            const cudaVersion = await this.detectJetsonCudaVersionAsync();
+            const driverVersion = this.detectJetsonDriverVersion() || 'unknown';
+            const totalSystemGB = Math.max(1, Math.round(os.totalmem() / (1024 ** 3)));
+            const sharedGpuMemoryGB = Math.max(1, Math.round(totalSystemGB * 0.85));
+            const capabilities = this.getJetsonCapabilities(modelRaw || model);
+            const speedCoefficient = this.getJetsonSpeedCoefficient(modelRaw || model);
+
+            return {
+                gpus: [
+                    {
+                        index: 0,
+                        name: model,
+                        uuid: null,
+                        memory: {
+                            total: sharedGpuMemoryGB,
+                            free: Math.max(0, sharedGpuMemoryGB - 1),
+                            used: Math.min(1, sharedGpuMemoryGB)
+                        },
+                        computeMode: 'Default',
+                        pcie: { generation: 0, width: 0 },
+                        power: { draw: 0, limit: 0 },
+                        temperature: 0,
+                        utilization: { gpu: 0, memory: 0 },
+                        clocks: { current: 0, max: 0 },
+                        capabilities,
+                        speedCoefficient
+                    }
+                ],
+                driver: driverVersion,
+                cuda: cudaVersion,
+                totalVRAM: sharedGpuMemoryGB,
+                backend: 'cuda',
+                isMultiGPU: false,
+                speedCoefficient
+            };
+        });
+    }
+
     detectJetsonCudaVersion() {
         const versionTxt = this.readFileIfExists('/usr/local/cuda/version.txt');
         if (versionTxt) {
@@ -447,6 +746,27 @@ class CUDADetector {
                 stdio: ['pipe', 'pipe', 'pipe']
             });
             const match = nvccVersion.match(/release\s+([\d.]+)/i);
+            if (match) return match[1];
+        } catch (e) {
+            // Ignore missing nvcc
+        }
+
+        return null;
+    }
+
+    async detectJetsonCudaVersionAsync() {
+        const versionTxt = this.readFileIfExists('/usr/local/cuda/version.txt');
+        if (versionTxt) {
+            const match = versionTxt.match(/CUDA Version\s+([\d.]+)/i);
+            if (match) return match[1];
+        }
+
+        try {
+            const nvccVersion = await this.execCommandAsync('nvcc --version', {
+                encoding: 'utf8',
+                timeout: 5000
+            });
+            const match = String(nvccVersion).match(/release\s+([\d.]+)/i);
             if (match) return match[1];
         } catch (e) {
             // Ignore missing nvcc

--- a/src/hardware/backends/intel-detector.js
+++ b/src/hardware/backends/intel-detector.js
@@ -7,11 +7,39 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { execFileAsync, filterLspciDisplayLines } = require('../probe-exec');
 
 class IntelDetector {
     constructor() {
         this.cache = null;
         this.isAvailable = null;
+    }
+
+    usesOverriddenDetect() {
+        return this.detect !== IntelDetector.prototype.detect;
+    }
+
+    usesOverriddenAvailability() {
+        return this.checkAvailability !== IntelDetector.prototype.checkAvailability;
+    }
+
+    hasIntelSysfs() {
+        try {
+            const renderNodes = fs.readdirSync('/sys/class/drm');
+            return renderNodes.some(node => {
+                try {
+                    const vendor = fs.readFileSync(
+                        `/sys/class/drm/${node}/device/vendor`,
+                        'utf8'
+                    ).trim();
+                    return vendor === '0x8086';
+                } catch (e) {
+                    return false;
+                }
+            });
+        } catch (e) {
+            return false;
+        }
     }
 
     /**
@@ -59,6 +87,32 @@ class IntelDetector {
         return this.isAvailable;
     }
 
+    async checkAvailabilityAsync() {
+        if (this.usesOverriddenAvailability()) {
+            return this.checkAvailability();
+        }
+
+        if (this.isAvailable !== null) {
+            return this.isAvailable;
+        }
+
+        if (process.platform !== 'linux') {
+            this.isAvailable = false;
+            return false;
+        }
+
+        try {
+            const lspci = filterLspciDisplayLines(
+                await execFileAsync('lspci', [], { encoding: 'utf8', timeout: 5000 })
+            );
+            this.isAvailable = /intel/i.test(lspci);
+        } catch (e) {
+            this.isAvailable = this.hasIntelSysfs();
+        }
+
+        return this.isAvailable;
+    }
+
     /**
      * Detect Intel GPUs
      */
@@ -73,6 +127,28 @@ class IntelDetector {
 
         try {
             const info = this.getGPUInfo();
+            this.cache = info;
+            return info;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async detectAsync() {
+        if (this.usesOverriddenDetect()) {
+            return this.detect();
+        }
+
+        if (!(await this.checkAvailabilityAsync())) {
+            return null;
+        }
+
+        if (this.cache) {
+            return this.cache;
+        }
+
+        try {
+            const info = await this.getGPUInfoAsync();
             this.cache = info;
             return info;
         } catch (error) {
@@ -180,6 +256,114 @@ class IntelDetector {
             : 0;
 
         return result;
+    }
+
+    async getGPUInfoAsync() {
+        const result = {
+            gpus: [],
+            totalVRAM: 0,
+            backend: 'sycl',
+            isMultiGPU: false,
+            hasDedicated: false,
+            speedCoefficient: 0
+        };
+
+        try {
+            const lspci = await execFileAsync('lspci', ['-v'], {
+                encoding: 'utf8',
+                timeout: 10000
+            });
+            this._applyIntelLspci(result, lspci);
+        } catch (e) {
+            if (!this._applyIntelSysfs(result)) {
+                return null;
+            }
+        }
+
+        if (result.gpus.length === 0) {
+            if (!this._applyIntelSysfs(result)) {
+                return null;
+            }
+        }
+
+        if (result.gpus.length === 0) {
+            return null;
+        }
+
+        result.isMultiGPU = result.gpus.filter(g => g.type === 'dedicated').length > 1;
+        result.speedCoefficient = result.gpus.length > 0
+            ? Math.max(...result.gpus.map(g => g.speedCoefficient))
+            : 0;
+
+        return result;
+    }
+
+    _applyIntelLspci(result, lspci) {
+        const gpuBlocks = String(lspci || '').split(/(?=\d{2}:\d{2}\.\d)/);
+
+        for (const block of gpuBlocks) {
+            if (!block.trim()) continue;
+            if (!/VGA|3D|Display/i.test(block) || !/intel/i.test(block)) continue;
+
+            const nameMatch = block.match(/Intel.*?(Arc|Iris|UHD|HD Graphics)[^\n]*/i);
+            if (!nameMatch) continue;
+
+            const name = nameMatch[0].replace(/Corporation\s*/i, '').trim();
+            const isDedicated = name.toLowerCase().includes('arc');
+            let vram = this.estimateVRAM(name) || this.getVRAMFromSysfs(block);
+
+            const gpu = {
+                index: result.gpus.length,
+                name: name,
+                type: isDedicated ? 'dedicated' : 'integrated',
+                memory: {
+                    total: vram,
+                    shared: isDedicated ? 0 : vram
+                },
+                capabilities: this.getGPUCapabilities(name),
+                speedCoefficient: this.calculateSpeedCoefficient(name, vram, isDedicated)
+            };
+
+            result.gpus.push(gpu);
+            if (isDedicated) {
+                result.totalVRAM += vram;
+                result.hasDedicated = true;
+            }
+        }
+    }
+
+    _applyIntelSysfs(result) {
+        try {
+            const drmPath = '/sys/class/drm';
+            const cards = fs.readdirSync(drmPath).filter(f => f.startsWith('card') && !f.includes('-'));
+
+            for (const card of cards) {
+                const vendorPath = path.join(drmPath, card, 'device/vendor');
+                try {
+                    const vendor = fs.readFileSync(vendorPath, 'utf8').trim();
+                    if (vendor !== '0x8086') continue;
+
+                    const devicePath = path.join(drmPath, card, 'device/device');
+                    const deviceId = fs.readFileSync(devicePath, 'utf8').trim();
+
+                    const gpuInfo = this.getGPUFromDeviceId(deviceId);
+                    result.gpus.push({
+                        index: result.gpus.length,
+                        ...gpuInfo
+                    });
+
+                    if (gpuInfo.type === 'dedicated') {
+                        result.totalVRAM += gpuInfo.memory.total;
+                        result.hasDedicated = true;
+                    }
+                } catch (e) {
+                    continue;
+                }
+            }
+            return result.gpus.length > 0;
+        } catch (e2) {
+            return false;
+        }
     }
 
     /**

--- a/src/hardware/backends/rocm-detector.js
+++ b/src/hardware/backends/rocm-detector.js
@@ -9,12 +9,21 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { execFileAsync, filterLspciDisplayLines } = require('../probe-exec');
 
 class ROCmDetector {
     constructor() {
         this.cache = null;
         this.isAvailable = null;
         this.detectionMethod = null;  // 'rocm-smi', 'rocminfo', 'lspci', 'sysfs'
+    }
+
+    usesOverriddenDetect() {
+        return this.detect !== ROCmDetector.prototype.detect;
+    }
+
+    usesOverriddenAvailability() {
+        return this.checkAvailability !== ROCmDetector.prototype.checkAvailability;
     }
 
     // AMD PCI device IDs for model name resolution
@@ -150,6 +159,103 @@ class ROCmDetector {
         return false;
     }
 
+    async tryRocmSmiAvailable() {
+        try {
+            await execFileAsync('rocm-smi', ['--version'], { encoding: 'utf8', timeout: 5000 });
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    async tryRocmInfoAvailable() {
+        try {
+            await execFileAsync('rocminfo', [], { encoding: 'utf8', timeout: 5000 });
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    async tryLspciAmdAvailable() {
+        try {
+            const lspci = filterLspciDisplayLines(
+                await execFileAsync('lspci', ['-nn'], { encoding: 'utf8', timeout: 5000 })
+            );
+            return /AMD|ATI|Radeon/i.test(lspci);
+        } catch (e) {
+            return false;
+        }
+    }
+
+    hasAmdSysfs() {
+        try {
+            const drmPath = '/sys/class/drm';
+            const entries = fs.readdirSync(drmPath);
+            return entries.some(node => {
+                try {
+                    const vendorPath = path.join(drmPath, node, 'device/vendor');
+                    const vendor = fs.readFileSync(vendorPath, 'utf8').trim();
+                    return vendor === '0x1002';
+                } catch (e) {
+                    return false;
+                }
+            });
+        } catch (e) {
+            return false;
+        }
+    }
+
+    async checkAvailabilityAsync() {
+        if (this.usesOverriddenAvailability()) {
+            return this.checkAvailability();
+        }
+
+        if (this.isAvailable !== null) {
+            return this.isAvailable;
+        }
+
+        if (process.platform !== 'linux') {
+            if (await this.tryRocmSmiAvailable()) {
+                this.isAvailable = true;
+                this.detectionMethod = 'rocm-smi';
+                return true;
+            }
+            this.isAvailable = false;
+            return false;
+        }
+
+        const [rocmSmi, rocminfo, lspciAmd] = await Promise.all([
+            this.tryRocmSmiAvailable(),
+            this.tryRocmInfoAvailable(),
+            this.tryLspciAmdAvailable()
+        ]);
+
+        if (rocmSmi) {
+            this.isAvailable = true;
+            this.detectionMethod = 'rocm-smi';
+            return true;
+        }
+        if (rocminfo) {
+            this.isAvailable = true;
+            this.detectionMethod = 'rocminfo';
+            return true;
+        }
+        if (lspciAmd) {
+            this.isAvailable = true;
+            this.detectionMethod = 'lspci';
+            return true;
+        }
+        if (this.hasAmdSysfs()) {
+            this.isAvailable = true;
+            this.detectionMethod = 'sysfs';
+            return true;
+        }
+
+        this.isAvailable = false;
+        return false;
+    }
+
     /**
      * Detect all AMD GPUs and their capabilities
      */
@@ -164,6 +270,28 @@ class ROCmDetector {
 
         try {
             const info = this.getGPUInfo();
+            this.cache = info;
+            return info;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async detectAsync() {
+        if (this.usesOverriddenDetect()) {
+            return this.detect();
+        }
+
+        if (!(await this.checkAvailabilityAsync())) {
+            return null;
+        }
+
+        if (this.cache) {
+            return this.cache;
+        }
+
+        try {
+            const info = await this.getGPUInfoAsync();
             this.cache = info;
             return info;
         } catch (error) {
@@ -204,6 +332,47 @@ class ROCmDetector {
         }
 
         // 4. Try sysfs
+        if (!detected && (this.detectionMethod === 'sysfs' || !this.detectionMethod)) {
+            detected = this._detectViaSysfs(result);
+        }
+
+        if (!detected || result.gpus.length === 0) {
+            return null;
+        }
+
+        result.isMultiGPU = result.gpus.length > 1;
+        result.speedCoefficient = result.gpus.length > 0
+            ? Math.max(...result.gpus.map(g => g.speedCoefficient))
+            : 0;
+
+        return result;
+    }
+
+    async getGPUInfoAsync() {
+        const result = {
+            gpus: [],
+            rocmVersion: null,
+            totalVRAM: 0,
+            totalSharedMemory: 0,
+            backend: 'rocm',
+            isMultiGPU: false,
+            speedCoefficient: 0
+        };
+
+        let detected = false;
+
+        if (this.detectionMethod === 'rocm-smi' || !this.detectionMethod) {
+            detected = await this._detectViaRocmSmiAsync(result);
+        }
+
+        if (!detected && (this.detectionMethod === 'rocminfo' || !this.detectionMethod)) {
+            detected = await this._detectViaRocmInfoAsync(result);
+        }
+
+        if (!detected && (this.detectionMethod === 'lspci' || !this.detectionMethod)) {
+            detected = await this._detectViaLspciAsync(result);
+        }
+
         if (!detected && (this.detectionMethod === 'sysfs' || !this.detectionMethod)) {
             detected = this._detectViaSysfs(result);
         }
@@ -281,6 +450,90 @@ class ROCmDetector {
             }
 
             // Build GPU list
+            const numGPUs = Math.max(gpuNames.length, Object.keys(gpuMemory).length);
+            for (let i = 0; i < numGPUs; i++) {
+                const name = gpuNames[i] || `AMD GPU ${i}`;
+                const detectedVram = gpuMemory[i];
+                const memoryProfile = this.resolveGpuMemoryProfile(name, detectedVram);
+                const vram = memoryProfile.total;
+
+                if (!Number.isFinite(vram) || vram <= 0) {
+                    continue;
+                }
+
+                const gpu = {
+                    index: i,
+                    name: name,
+                    type: memoryProfile.type,
+                    memory: {
+                        total: vram,
+                        free: vram,
+                        used: 0,
+                        dedicated: memoryProfile.dedicated,
+                        shared: memoryProfile.shared
+                    },
+                    dedicatedMemory: memoryProfile.dedicated,
+                    sharedMemory: memoryProfile.shared,
+                    unifiedMemory: memoryProfile.type === 'integrated' ? memoryProfile.shared : 0,
+                    temperature: temps[i] || 0,
+                    utilization: utils[i] || 0,
+                    capabilities: this.getGPUCapabilities(name),
+                    speedCoefficient: this.calculateSpeedCoefficient(name, vram)
+                };
+
+                result.gpus.push(gpu);
+                result.totalVRAM += memoryProfile.type === 'integrated' ? memoryProfile.dedicated : vram;
+                result.totalSharedMemory += memoryProfile.type === 'integrated' ? memoryProfile.shared : 0;
+            }
+
+            return result.gpus.length > 0;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    async _detectViaRocmSmiAsync(result) {
+        try {
+            const versionOutput = await execFileAsync('rocm-smi', ['--version'], {
+                encoding: 'utf8',
+                timeout: 5000
+            });
+            const match = String(versionOutput).match(/(\d+\.\d+\.?\d*)/);
+            if (match) {
+                result.rocmVersion = match[1];
+            }
+        } catch (e) {
+            return false;
+        }
+
+        try {
+            const [gpuList, memInfo] = await Promise.all([
+                execFileAsync('rocm-smi', ['--showproductname'], { encoding: 'utf8', timeout: 10000 }),
+                execFileAsync('rocm-smi', ['--showmeminfo', 'vram'], { encoding: 'utf8', timeout: 10000 })
+            ]);
+
+            const gpuNames = this.parseRocmSmiProductNames(gpuList);
+            const gpuMemory = this.parseRocmSmiMemoryInfo(memInfo);
+
+            let temps = {};
+            let utils = {};
+            try {
+                const [tempInfo, utilInfo] = await Promise.all([
+                    execFileAsync('rocm-smi', ['--showtemp'], { encoding: 'utf8', timeout: 5000 }),
+                    execFileAsync('rocm-smi', ['--showuse'], { encoding: 'utf8', timeout: 5000 })
+                ]);
+                const tempMatches = String(tempInfo).matchAll(/GPU\[(\d+)\].*?Temperature.*?:\s*(\d+\.?\d*)/g);
+                for (const match of tempMatches) {
+                    temps[parseInt(match[1])] = parseFloat(match[2]);
+                }
+                const utilMatches = String(utilInfo).matchAll(/GPU\[(\d+)\].*?GPU use.*?:\s*(\d+)/g);
+                for (const match of utilMatches) {
+                    utils[parseInt(match[1])] = parseInt(match[2]);
+                }
+            } catch (e) {
+                // Continue without temp/util
+            }
+
             const numGPUs = Math.max(gpuNames.length, Object.keys(gpuMemory).length);
             for (let i = 0; i < numGPUs; i++) {
                 const name = gpuNames[i] || `AMD GPU ${i}`;
@@ -790,6 +1043,50 @@ class ROCmDetector {
         }
     }
 
+    async _detectViaRocmInfoAsync(result) {
+        try {
+            const rocmInfo = await execFileAsync('rocminfo', [], {
+                encoding: 'utf8',
+                timeout: 10000
+            });
+            const agents = this.parseRocmInfoGpuAgents(rocmInfo);
+            for (let index = 0; index < agents.length; index += 1) {
+                const name = agents[index].name;
+                let vram = this.estimateVRAMFromGfxName(name);
+                const memoryProfile = this.resolveGpuMemoryProfile(name, vram);
+                vram = memoryProfile.total;
+
+                if (!Number.isFinite(vram) || vram <= 0) {
+                    vram = 8;
+                }
+
+                result.gpus.push({
+                    index,
+                    name,
+                    type: memoryProfile.type,
+                    memory: {
+                        total: vram,
+                        free: vram,
+                        used: 0,
+                        dedicated: memoryProfile.dedicated,
+                        shared: memoryProfile.shared
+                    },
+                    dedicatedMemory: memoryProfile.dedicated,
+                    sharedMemory: memoryProfile.shared,
+                    unifiedMemory: memoryProfile.type === 'integrated' ? memoryProfile.shared : 0,
+                    capabilities: this.getGPUCapabilities(name),
+                    speedCoefficient: this.calculateSpeedCoefficient(name, vram)
+                });
+                result.totalVRAM += memoryProfile.type === 'integrated' ? memoryProfile.dedicated : vram;
+                result.totalSharedMemory += memoryProfile.type === 'integrated' ? memoryProfile.shared : 0;
+            }
+
+            return result.gpus.length > 0;
+        } catch (e) {
+            return false;
+        }
+    }
+
     /**
      * Detect GPUs via lspci (fallback when ROCm is not installed)
      */
@@ -863,6 +1160,76 @@ class ROCmDetector {
         } catch (e) {
             return false;
         }
+    }
+
+    async _detectViaLspciAsync(result) {
+        try {
+            const lspciOutput = filterLspciDisplayLines(
+                await execFileAsync('lspci', ['-nn'], {
+                    encoding: 'utf8',
+                    timeout: 10000
+                })
+            );
+            return this._applyLspciOutput(result, lspciOutput);
+        } catch (e) {
+            return false;
+        }
+    }
+
+    _applyLspciOutput(result, lspciOutput) {
+        const lines = String(lspciOutput || '').trim().split('\n');
+        let idx = result.gpus.length;
+
+        for (const line of lines) {
+            const amdMatch = line.match(/\[(?:AMD|ATI)\].*?\[([0-9a-f]{4}):([0-9a-f]{4})\]/i) ||
+                             line.match(/(?:AMD|ATI|Radeon).*?\[([0-9a-f]{4}):([0-9a-f]{4})\]/i);
+
+            if (!amdMatch) continue;
+
+            const vendorId = amdMatch[1].toLowerCase();
+            if (vendorId !== '1002') continue;
+
+            const deviceId = amdMatch[2].toLowerCase();
+            const deviceInfo = ROCmDetector.AMD_DEVICE_IDS[deviceId];
+
+            let lspciName = null;
+            const nameMatch = line.match(/\[(?:AMD|ATI)\]\s*(.+?)\s*\[/);
+            if (nameMatch) {
+                lspciName = nameMatch[1].trim();
+            }
+
+            const reportedStrixModel = deviceId === '1586'
+                ? this.getReportedStrixHaloModel(line)
+                : null;
+            const name = reportedStrixModel || deviceInfo?.name ||
+                this._resolveAMDModelName(lspciName, deviceId) || `AMD GPU (${deviceId})`;
+            const vram = deviceInfo?.vram || this.estimateVRAMFromModel(name);
+            const sysfsVram = this._getVRAMFromSysfsForDevice(deviceId);
+            const memoryProfile = this.resolveGpuMemoryProfile(name, sysfsVram || vram);
+
+            result.gpus.push({
+                index: idx,
+                name: name,
+                type: memoryProfile.type,
+                memory: {
+                    total: memoryProfile.total,
+                    free: memoryProfile.total,
+                    used: 0,
+                    dedicated: memoryProfile.dedicated,
+                    shared: memoryProfile.shared
+                },
+                dedicatedMemory: memoryProfile.dedicated,
+                sharedMemory: memoryProfile.shared,
+                unifiedMemory: memoryProfile.type === 'integrated' ? memoryProfile.shared : 0,
+                capabilities: this.getGPUCapabilities(name),
+                speedCoefficient: this.calculateSpeedCoefficient(name, memoryProfile.total)
+            });
+            result.totalVRAM += memoryProfile.type === 'integrated' ? memoryProfile.dedicated : memoryProfile.total;
+            result.totalSharedMemory += memoryProfile.type === 'integrated' ? memoryProfile.shared : 0;
+            idx++;
+        }
+
+        return result.gpus.length > 0;
     }
 
     /**

--- a/src/hardware/probe-exec.js
+++ b/src/hardware/probe-exec.js
@@ -1,0 +1,111 @@
+/**
+ * Async hardware probe runner.
+ * Independent detectors overlap via Promise.all when they use execFile
+ * instead of blocking execSync/spawnSync.
+ */
+
+const { execFile, exec } = require('child_process');
+
+const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_MAX_BUFFER = 8 * 1024 * 1024;
+
+function execFileAsync(file, args = [], options = {}) {
+    const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+    return new Promise((resolve, reject) => {
+        execFile(file, args, {
+            encoding: options.encoding || 'utf8',
+            timeout,
+            maxBuffer: options.maxBuffer || DEFAULT_MAX_BUFFER,
+            windowsHide: true,
+            env: options.env,
+            cwd: options.cwd
+        }, (error, stdout, stderr) => {
+            if (error) {
+                error.stdout = stdout;
+                error.stderr = stderr;
+                reject(error);
+                return;
+            }
+            resolve(stdout);
+        });
+    });
+}
+
+function execShellAsync(command, options = {}) {
+    const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+    return new Promise((resolve, reject) => {
+        exec(command, {
+            encoding: options.encoding || 'utf8',
+            timeout,
+            maxBuffer: options.maxBuffer || DEFAULT_MAX_BUFFER,
+            windowsHide: true,
+            env: options.env,
+            cwd: options.cwd
+        }, (error, stdout, stderr) => {
+            if (error) {
+                error.stdout = stdout;
+                error.stderr = stderr;
+                reject(error);
+                return;
+            }
+            resolve(stdout);
+        });
+    });
+}
+
+function needsShell(command) {
+    return /[|<>;&`$(){}]/.test(command);
+}
+
+function splitArgs(command) {
+    const parts = [];
+    let current = '';
+    let quote = null;
+    for (let i = 0; i < command.length; i++) {
+        const ch = command[i];
+        if (quote) {
+            if (ch === quote) quote = null;
+            else current += ch;
+            continue;
+        }
+        if (ch === '"' || ch === "'") {
+            quote = ch;
+            continue;
+        }
+        if (/\s/.test(ch)) {
+            if (current) {
+                parts.push(current);
+                current = '';
+            }
+            continue;
+        }
+        current += ch;
+    }
+    if (current) parts.push(current);
+    return parts;
+}
+
+async function execCommandAsync(command, options = {}) {
+    const cmd = String(command).trim();
+    if (!cmd) {
+        throw new Error('Empty command');
+    }
+    if (options.shell || needsShell(cmd)) {
+        return execShellAsync(cmd, options);
+    }
+    const parts = splitArgs(cmd);
+    return execFileAsync(parts[0], parts.slice(1), options);
+}
+
+function filterLspciDisplayLines(output) {
+    return String(output || '')
+        .split('\n')
+        .filter((line) => /VGA|3D|Display/i.test(line))
+        .join('\n');
+}
+
+module.exports = {
+    execFileAsync,
+    execCommandAsync,
+    filterLspciDisplayLines
+};

--- a/src/hardware/unified-detector.js
+++ b/src/hardware/unified-detector.js
@@ -10,7 +10,7 @@ const ROCmDetector = require('./backends/rocm-detector');
 const IntelDetector = require('./backends/intel-detector');
 const CPUDetector = require('./backends/cpu-detector');
 const si = require('systeminformation');
-const { execSync } = require('child_process');
+const { execFileAsync, filterLspciDisplayLines } = require('./probe-exec');
 const { normalizePlatform } = require('../utils/platform');
 const { applyCpuOnlyOverride, resolveCpuOnlyMode } = require('./cpu-only');
 
@@ -89,95 +89,100 @@ class UnifiedDetector {
             timestamp: Date.now()
         };
 
-        // Detect CPU first (always available)
-        try {
-            result.cpu = this.backends.cpu.detect();
-            result.backends.cpu = {
-                available: true,
-                info: result.cpu
-            };
-        } catch (e) {
-            result.backends.cpu = { available: false, error: e.message };
-        }
+        // Independent backend probes overlap via async execFile. Sync detect()
+        // remains for tests/callers that monkey-patch execSync.
+        const probes = [
+            (async () => {
+                try {
+                    result.cpu = await this.backends.cpu.detectAsync();
+                    result.backends.cpu = {
+                        available: true,
+                        info: result.cpu
+                    };
+                } catch (e) {
+                    result.backends.cpu = { available: false, error: e.message };
+                }
+            })(),
+            (async () => {
+                try {
+                    const cudaInfo = await this.backends.cuda.detectAsync();
+                    if (cudaInfo && cudaInfo.gpus.length > 0) {
+                        result.backends.cuda = {
+                            available: true,
+                            info: cudaInfo
+                        };
+                    }
+                } catch (e) {
+                    result.backends.cuda = { available: false, error: e.message };
+                }
+            })(),
+            (async () => {
+                try {
+                    const rocmInfo = await this.backends.rocm.detectAsync();
+                    if (rocmInfo && rocmInfo.gpus.length > 0) {
+                        result.backends.rocm = {
+                            available: true,
+                            info: rocmInfo
+                        };
+                    }
+                } catch (e) {
+                    result.backends.rocm = { available: false, error: e.message };
+                }
+            })()
+        ];
 
-        // Detect Apple Silicon (macOS ARM only)
         if (platform === 'darwin' && process.arch === 'arm64') {
-            try {
-                const metalInfo = this.backends.metal.detect();
-                if (metalInfo) {
-                    result.backends.metal = {
-                        available: true,
-                        info: metalInfo
-                    };
+            probes.push((async () => {
+                try {
+                    const metalInfo = await this.backends.metal.detectAsync();
+                    if (metalInfo) {
+                        result.backends.metal = {
+                            available: true,
+                            info: metalInfo
+                        };
+                    }
+                } catch (e) {
+                    result.backends.metal = { available: false, error: e.message };
                 }
-            } catch (e) {
-                result.backends.metal = { available: false, error: e.message };
-            }
+            })());
         }
 
-        // Detect NVIDIA CUDA
-        try {
-            if (this.backends.cuda.checkAvailability()) {
-                const cudaInfo = this.backends.cuda.detect();
-                if (cudaInfo && cudaInfo.gpus.length > 0) {
-                    result.backends.cuda = {
-                        available: true,
-                        info: cudaInfo
-                    };
-                }
-            }
-        } catch (e) {
-            result.backends.cuda = { available: false, error: e.message };
-        }
-
-        // Detect AMD ROCm
-        try {
-            if (this.backends.rocm.checkAvailability()) {
-                const rocmInfo = this.backends.rocm.detect();
-                if (rocmInfo && rocmInfo.gpus.length > 0) {
-                    result.backends.rocm = {
-                        available: true,
-                        info: rocmInfo
-                    };
-                }
-            }
-        } catch (e) {
-            result.backends.rocm = { available: false, error: e.message };
-        }
-
-        // Detect Intel (Linux only for now)
         if (platform === 'linux') {
-            try {
-                if (this.backends.intel.checkAvailability()) {
-                    const intelInfo = this.backends.intel.detect();
+            probes.push((async () => {
+                try {
+                    const intelInfo = await this.backends.intel.detectAsync();
                     if (intelInfo && intelInfo.gpus.length > 0) {
                         result.backends.intel = {
                             available: true,
                             info: intelInfo
                         };
                     }
+                } catch (e) {
+                    result.backends.intel = { available: false, error: e.message };
                 }
-            } catch (e) {
-                result.backends.intel = { available: false, error: e.message };
-            }
+            })());
         }
 
         // Always collect a generic GPU inventory on Windows/Linux so integrated
         // GPUs remain visible even when a dedicated backend is selected.
         if (platform === 'win32' || platform === 'linux') {
-            try {
-                const genericGpuInfo = await this.detectSystemGpuFallback();
-                if (genericGpuInfo?.available) {
-                    result.systemGpu = genericGpuInfo;
-                    result.backends.generic = {
-                        available: true,
-                        info: genericGpuInfo
-                    };
+            probes.push((async () => {
+                try {
+                    const genericGpuInfo = await this.detectSystemGpuFallback();
+                    if (genericGpuInfo?.available) {
+                        result.systemGpu = genericGpuInfo;
+                        result.backends.generic = {
+                            available: true,
+                            info: genericGpuInfo
+                        };
+                    }
+                } catch (e) {
+                    result.backends.generic = { available: false, error: e.message };
                 }
-            } catch (e) {
-                result.backends.generic = { available: false, error: e.message };
-            }
+            })());
         }
+
+        await Promise.all(probes);
 
         // Select the best available backend
         result.primary = this.selectPrimaryBackend(result.backends);
@@ -713,7 +718,7 @@ class UnifiedDetector {
         const platform = normalizePlatform();
 
         if (platform === 'linux') {
-            const lspciControllers = this.detectLinuxLspciGpus();
+            const lspciControllers = await this.detectLinuxLspciGpus();
             const knownKeys = new Set(
                 normalized.map((gpu) => this.getGpuMatchKey(gpu.name)).filter(Boolean)
             );
@@ -752,13 +757,14 @@ class UnifiedDetector {
         };
     }
 
-    detectLinuxLspciGpus() {
+    async detectLinuxLspciGpus() {
         try {
-            const lspciOutput = execSync('lspci -nn | grep -Ei "VGA|3D|Display"', {
-                encoding: 'utf8',
-                timeout: 8000,
-                stdio: ['pipe', 'pipe', 'pipe']
-            });
+            const lspciOutput = filterLspciDisplayLines(
+                await execFileAsync('lspci', ['-nn'], {
+                    encoding: 'utf8',
+                    timeout: 8000
+                })
+            );
             return this.parseLinuxLspciGpus(lspciOutput);
         } catch (error) {
             return [];

--- a/tests/database-backends.test.js
+++ b/tests/database-backends.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const Module = require('module');
+const ModelDatabase = require('../src/data/model-database');
+
+async function run() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-sqlite-'));
+    let nativeAvailable = false;
+    try { nativeAvailable = Boolean(require('node:sqlite').DatabaseSync); } catch {}
+    const modes = nativeAvailable ? ['wasm', 'native'] : ['wasm'];
+    const outputs = [];
+    try {
+        for (const sqliteBackend of modes) {
+            const options = { dbPath: path.join(dir, `${sqliteBackend}.db`), sqliteBackend };
+            const db = new ModelDatabase(options);
+            try {
+                await db.initialize();
+                assert.strictEqual(db.useNativeSqlite, sqliteBackend === 'native');
+                outputs.push(db.all('SELECT * FROM model_artifacts ORDER BY id'));
+                assert.strictEqual(db.get('SELECT id FROM models WHERE id = ?', ['missing-model']), null);
+                db.beginBatch(); db.beginBatch();
+                db.upsertModel({ id: 'test-model', name: "Quoted ' model", description: 'Unicode: café 日本語' });
+                db.upsertVariant({ model_id: 'test-model', tag: 'test-model:1b', params_b: 1, size_gb: 0.5 });
+                db.endBatch(); db.endBatch();
+                db.close();
+                await db.initialize();
+                assert.strictEqual(db.get('SELECT description FROM models WHERE id = ?', ['test-model']).description, 'Unicode: café 日本語');
+                assert.strictEqual(db.get('SELECT params_b FROM variants WHERE model_id = ?', ['test-model']).params_b, 1);
+                assert.throws(() => db.all('SELECT missing_column FROM models'));
+                assert.strictEqual(db.get('SELECT 1 AS n').n, 1, 'query errors leave the connection usable');
+            } finally { db.close(); }
+        }
+        if (outputs.length === 2) assert.deepStrictEqual(outputs[1], outputs[0], 'native and WASM return the same full catalog');
+
+        // Auto mode must work when Node has no built-in SQLite. Conversely,
+        // supported Node versions must never require the optional WASM package.
+        const originalLoad = Module._load;
+        for (const block of nativeAvailable ? ['node:sqlite', 'sql.js'] : ['node:sqlite']) {
+            const db = new ModelDatabase({ dbPath: path.join(dir, `auto-${block.replace(/\W/g, '-')}.db`) });
+            Module._load = function(id, ...args) {
+                if (id === block) {
+                    const error = new Error(`Unavailable: ${id}`);
+                    error.code = 'MODULE_NOT_FOUND';
+                    throw error;
+                }
+                return originalLoad.call(this, id, ...args);
+            };
+            try {
+                await db.initialize();
+                assert.strictEqual(db.useNativeSqlite, block === 'sql.js');
+                assert.ok(db.getModelCount() > 100);
+            } finally { Module._load = originalLoad; db.close(); }
+        }
+        console.log(`database-backends.test.js: OK (${modes.join(', ')})`);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+if (require.main === module) run().catch((error) => { console.error(error); process.exitCode = 1; });
+module.exports = { run };

--- a/tests/default-model-safety.test.js
+++ b/tests/default-model-safety.test.js
@@ -1,4 +1,6 @@
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -231,9 +233,10 @@ async function testOllamaDescriptionOnlyModel() {
 
 async function testPackagedSeedDescriptionOnlyModel() {
     const seedDbPath = path.join(__dirname, '..', 'src', 'data', 'seed', 'models.db');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-safety-seed-'));
     const database = new ModelDatabase({
-        dbPath: seedDbPath,
-        seedDbPath: path.join(__dirname, 'missing-seed.db'),
+        dbPath: path.join(dir, 'models.db'),
+        seedDbPath,
         disableRegistrySeedImport: true
     });
 
@@ -286,6 +289,7 @@ async function testPackagedSeedDescriptionOnlyModel() {
         assert.ok(explicitResult.recommendations.some((item) => item.model === 'dolphin-mixtral'));
     } finally {
         database.close();
+        fs.rmSync(dir, { recursive: true, force: true });
     }
 }
 

--- a/tests/hardware-parallel-probes.test.js
+++ b/tests/hardware-parallel-probes.test.js
@@ -5,6 +5,9 @@
  */
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const UnifiedDetector = require('../src/hardware/unified-detector');
 const { execFileAsync, filterLspciDisplayLines } = require('../src/hardware/probe-exec');
 
@@ -47,9 +50,7 @@ async function testIndependentBackendsOverlap() {
         hasDedicated: false
     });
 
-    const t0 = Date.now();
     const result = await detector.detect();
-    const elapsed = Date.now() - t0;
 
     assert.ok(result.backends.cpu?.available, 'CPU backend should remain available');
     assert.strictEqual(result.backends.cuda?.available, true, 'CUDA backend should remain available');
@@ -57,9 +58,8 @@ async function testIndependentBackendsOverlap() {
     assert.strictEqual(result.summary.bestBackend, 'cuda', 'Summary contract must stay cuda-first');
     assert.ok(typeof result.fingerprint === 'string' && result.fingerprint.length > 0, 'Fingerprint must still be produced');
 
-    const startSpread = Math.max(...started.map((s) => s.t)) - Math.min(...started.map((s) => s.t));
-    assert.ok(startSpread < 40, `probes should start together, spread was ${startSpread}ms`);
-    assert.ok(elapsed < 200, `wall time should approach the slowest probe, not the sum; got ${elapsed}ms`);
+    assert.ok(Math.max(...started.map((s) => s.t)) <= Math.min(...finished.map((s) => s.t)),
+        'every independent probe must start before the first probe completes');
 }
 
 async function testOverriddenSyncDetectStillWorks() {
@@ -114,6 +114,25 @@ async function main() {
     await testIndependentBackendsOverlap();
     await testOverriddenSyncDetectStillWorks();
     await testExecFileAndLspciFilter();
+    // Real child processes rendezvous through files: serial execution cannot
+    // finish, because the first child waits for the other two to start.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-probe-'));
+    try {
+        const child = `const fs = require('fs'); const path = require('path');
+            fs.writeFileSync(path.join(process.argv[1], process.argv[2]), 'ready');
+            const timer = setInterval(() => {
+                if (fs.readdirSync(process.argv[1]).length === 3) {
+                    clearInterval(timer); process.stdout.write('overlapped');
+                }
+            }, 10);`;
+        const results = await Promise.all([0, 1, 2].map((id) => execFileAsync(process.execPath,
+            ['-e', child, dir, String(id)], { timeout: 5000 })));
+        assert.deepStrictEqual(results, ['overlapped', 'overlapped', 'overlapped']);
+        await assert.rejects(execFileAsync(process.execPath,
+            ['-e', 'setInterval(() => {}, 1000)'], { timeout: 100 }),
+        (error) => error.killed === true, 'stalled probes must be killed at their deadline');
+        await assert.rejects(execFileAsync(path.join(dir, 'missing-probe')), /ENOENT/);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
     console.log('hardware-parallel-probes: ok');
 }
 

--- a/tests/hardware-parallel-probes.test.js
+++ b/tests/hardware-parallel-probes.test.js
@@ -24,6 +24,10 @@ async function testIndependentBackendsOverlap() {
         started.push({ label, t: Date.now() });
         await delay(ms);
         finished.push({ label, t: Date.now() });
+        // Real detectAsync stores these before fingerprint generation. Keep the
+        // fixture independent of whether the CI host has NVIDIA tools/devices.
+        detector.backends[label].cache = value;
+        detector.backends[label].isAvailable = Boolean(value);
         return value;
     };
 

--- a/tests/hardware-parallel-probes.test.js
+++ b/tests/hardware-parallel-probes.test.js
@@ -1,0 +1,123 @@
+/**
+ * Hardware probe parallelism
+ * Independent backends must overlap via detectAsync + execFile,
+ * while the unified detect() result shape stays the same.
+ */
+
+const assert = require('assert');
+const UnifiedDetector = require('../src/hardware/unified-detector');
+const { execFileAsync, filterLspciDisplayLines } = require('../src/hardware/probe-exec');
+
+function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function testIndependentBackendsOverlap() {
+    const detector = new UnifiedDetector();
+    const started = [];
+    const finished = [];
+
+    const slow = (label, value, ms) => async () => {
+        started.push({ label, t: Date.now() });
+        await delay(ms);
+        finished.push({ label, t: Date.now() });
+        return value;
+    };
+
+    detector.backends.cpu.detectAsync = slow('cpu', {
+        brand: 'Test CPU',
+        speedCoefficient: 10
+    }, 80);
+    detector.backends.cuda.detectAsync = slow('cuda', {
+        gpus: [{ name: 'NVIDIA Test', memory: { total: 8 }, speedCoefficient: 90 }],
+        totalVRAM: 8,
+        backend: 'cuda',
+        isMultiGPU: false,
+        speedCoefficient: 90
+    }, 80);
+    detector.backends.rocm.detectAsync = slow('rocm', null, 80);
+    detector.backends.intel.detectAsync = slow('intel', null, 80);
+    detector.detectLinuxLspciGpus = async () => [];
+    detector.detectSystemGpuFallback = async () => ({
+        available: false,
+        source: 'test',
+        gpus: [],
+        totalVRAM: 0,
+        isMultiGPU: false,
+        hasDedicated: false
+    });
+
+    const t0 = Date.now();
+    const result = await detector.detect();
+    const elapsed = Date.now() - t0;
+
+    assert.ok(result.backends.cpu?.available, 'CPU backend should remain available');
+    assert.strictEqual(result.backends.cuda?.available, true, 'CUDA backend should remain available');
+    assert.strictEqual(result.primary?.type, 'cuda', 'Primary backend selection must be unchanged');
+    assert.strictEqual(result.summary.bestBackend, 'cuda', 'Summary contract must stay cuda-first');
+    assert.ok(typeof result.fingerprint === 'string' && result.fingerprint.length > 0, 'Fingerprint must still be produced');
+
+    const startSpread = Math.max(...started.map((s) => s.t)) - Math.min(...started.map((s) => s.t));
+    assert.ok(startSpread < 40, `probes should start together, spread was ${startSpread}ms`);
+    assert.ok(elapsed < 200, `wall time should approach the slowest probe, not the sum; got ${elapsed}ms`);
+}
+
+async function testOverriddenSyncDetectStillWorks() {
+    const detector = new UnifiedDetector();
+    detector.backends.cpu.detect = () => ({
+        brand: 'Stub CPU',
+        vendor: 'Test',
+        cores: { physical: 8, logical: 16, performance: 8, efficiency: 0 },
+        frequency: { base: 3000, max: 4000 },
+        cache: { l1d: 32, l1i: 32, l2: 1, l3: 16 },
+        capabilities: { bestSimd: 'AVX2', avx2: true },
+        architecture: 'x64',
+        backend: 'cpu',
+        speedCoefficient: 5
+    });
+    detector.backends.cuda.checkAvailability = () => false;
+    detector.backends.rocm.checkAvailability = () => false;
+    detector.backends.intel.checkAvailability = () => false;
+    detector.detectLinuxLspciGpus = async () => [];
+    detector.detectSystemGpuFallback = async () => ({
+        available: false,
+        gpus: [],
+        totalVRAM: 0,
+        isMultiGPU: false,
+        hasDedicated: false
+    });
+
+    const result = await detector.detect();
+    assert.strictEqual(result.cpu.brand, 'Stub CPU');
+    assert.strictEqual(result.backends.cpu.info.brand, 'Stub CPU');
+    assert.ok(!result.backends.cuda?.available, 'CUDA should stay unavailable when checkAvailability is stubbed false');
+}
+
+async function testExecFileAndLspciFilter() {
+    const out = await execFileAsync(process.execPath, ['-e', 'process.stdout.write("ok")'], {
+        encoding: 'utf8',
+        timeout: 5000
+    });
+    assert.strictEqual(String(out).trim(), 'ok');
+
+    const filtered = filterLspciDisplayLines([
+        '00:00.0 Host bridge: Intel',
+        '01:00.0 VGA compatible controller [0300]: NVIDIA',
+        '02:00.0 Audio device: NVIDIA'
+    ].join('\n'));
+    assert.ok(filtered.includes('VGA'));
+    assert.ok(!filtered.includes('Host bridge'));
+    assert.ok(!filtered.includes('Audio device'));
+}
+
+async function main() {
+    await testIndependentBackendsOverlap();
+    await testOverriddenSyncDetectStillWorks();
+    await testExecFileAndLspciFilter();
+    console.log('hardware-parallel-probes: ok');
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/tests/model-registry-param-parsing.test.js
+++ b/tests/model-registry-param-parsing.test.js
@@ -39,6 +39,7 @@ function testContextTokenNotMisreadAsParams() {
 function testRecommenderMoEParsing() {
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         source_name: 'Hugging Face Hub',
         repo_id: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
         canonical_model_id: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
@@ -55,6 +56,7 @@ function testRecommenderActiveParamTotalSizing() {
     // "397B-A17B" = 397B total / 17B active. Memory must be sized by the TOTAL.
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B'
@@ -71,6 +73,7 @@ function testRecommenderActiveParamTotalSizing() {
     // parameter_count_b, the name re-derivation must still size it as 397B.
     const stale = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B',
@@ -85,6 +88,7 @@ function testHugeMoEDoesNotFitSmallHardware() {
     const selector = new DeterministicModelSelector();
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B',
@@ -149,6 +153,7 @@ function testShardedFileSizeNotUsedAsModelSize() {
     // whose shard is 4.66GB must be sized from params, not "fit" as 4.66GB.
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'org/Big-56B',
         canonical_model_id: 'org/Big-56B',
         artifact_name: 'model-00001-of-00012.safetensors',

--- a/tests/model-registry-recommender.test.js
+++ b/tests/model-registry-recommender.test.js
@@ -151,6 +151,29 @@ async function run() {
         assert.ok(['vllm', 'transformers'].includes(hfResult.recommendations[0].runtime));
         assert.ok(hfResult.recommendations[0].download_url.includes('huggingface.co/example/CodeTiny-7B'));
 
+        // Count actual scoring calls: headers must describe each category, even
+        // when most candidates fail to fit or an entire category is empty.
+        const evaluateModel = recommender.selector.evaluateModel;
+        const calls = {};
+        recommender.selector.evaluateModel = function(model, hardware, category, ...args) {
+            calls[category] = (calls[category] || 0) + 1;
+            return evaluateModel.call(this, model, hardware, category, ...args);
+        };
+        for (const runtime of ['auto', 'ollama']) {
+            for (const key of Object.keys(calls)) delete calls[key];
+            const grouped = await recommender.getBestModelsForHardware(buildHardware(), {
+                runtime, categories: ['general', 'coding', 'multimodal'], limit: 1
+            });
+            for (const [category, group] of Object.entries(grouped.recommendations)) {
+                assert.strictEqual(group.totalCandidates, calls[category] || 0, `${runtime}/${category} header`);
+                assert.strictEqual(group.totalEvaluated, calls[category] || 0);
+            }
+            assert.ok(grouped.recommendations.general.totalCandidates > grouped.recommendations.coding.totalCandidates);
+            assert.strictEqual(grouped.recommendations.multimodal.totalCandidates, 0);
+            assert.ok(grouped.totalModelsAnalyzed > 0, 'global pool remains available separately');
+        }
+        recommender.selector.evaluateModel = evaluateModel;
+
         console.log('[OK] model-registry-recommender.test.js passed');
     } finally {
         database.close();

--- a/tests/model-registry-seed.test.js
+++ b/tests/model-registry-seed.test.js
@@ -7,9 +7,10 @@ const ModelDatabase = require('../src/data/model-database');
 
 async function run() {
     const seedDbPath = path.join(__dirname, '..', 'src', 'data', 'seed', 'models.db');
+    const seedTestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-seed-test-'));
     const database = new ModelDatabase({
-        dbPath: seedDbPath,
-        seedDbPath: path.join(__dirname, 'missing-seed.db')
+        dbPath: path.join(seedTestDir, 'models.db'),
+        seedDbPath
     });
 
     try {
@@ -68,6 +69,7 @@ async function run() {
         console.log('[OK] model-registry-seed.test.js passed');
     } finally {
         database.close();
+        fs.rmSync(seedTestDir, { recursive: true, force: true });
     }
 }
 

--- a/tests/registry-ingestor-quality.test.js
+++ b/tests/registry-ingestor-quality.test.js
@@ -11,9 +11,39 @@
 const assert = require('assert');
 const {
     isModelArtifactFile,
+    normalizeHuggingFaceModel,
     inferQuantization,
     normalizeGpt4AllEntry
 } = require('../src/data/registry-ingestors');
+const { artifactToSelectorModel } = require('../src/data/registry-recommender');
+
+function testLanguageModelRepositoryFiltering() {
+    const weights = [{ rfilename: 'model.safetensors', size: 4e9 }];
+    for (const model of [
+        { id: 'UmeAiRT/ComfyUI-Auto-Installer-Assets', library_name: 'diffusers', tags: ['gguf', 'comfyui'] },
+        { id: 'Kijai/WanVideo_comfy', library_name: 'diffusion-single-file' },
+        { id: 'org/video-7B', pipeline_tag: 'text-to-video', tags: ['text-generation'] },
+        { id: 'org/unknown-7B', tags: ['safetensors'] },
+        { id: 'org/adapter-7B', pipeline_tag: 'text-generation', library_name: 'peft' }
+    ]) {
+        assert.strictEqual(normalizeHuggingFaceModel({ ...model, siblings: weights }), null, model.id);
+        assert.strictEqual(artifactToSelectorModel({
+            source_id: 'huggingface', repo_id: model.id, parameter_count_b: 7,
+            artifact_name: 'model.safetensors', repo_metadata: model, repo_tags: model.tags
+        }), null, `cached ${model.id} must also be rejected`);
+    }
+    for (const task of ['text-generation', 'image-text-to-text', 'feature-extraction', 'sentence-similarity']) {
+        const model = { id: 'org/valid-7B', pipeline_tag: task, siblings: weights };
+        assert.strictEqual(normalizeHuggingFaceModel(model).artifacts.length, 1);
+        assert.ok(artifactToSelectorModel({
+            source_id: 'huggingface', repo_id: model.id, parameter_count_b: 7,
+            artifact_name: 'model.safetensors', repo_metadata: model
+        }));
+    }
+    assert.ok(normalizeHuggingFaceModel({
+        id: 'org/legacy-7B-GGUF', tags: ['gguf', 'text-generation'], siblings: weights
+    }), 'legacy task tags remain supported');
+}
 
 function testArtifactFileFiltering() {
     // Real model weights -> included
@@ -61,6 +91,7 @@ function testGpt4AllCanonicalFromHfRepo() {
 }
 
 function run() {
+    testLanguageModelRepositoryFiltering();
     testArtifactFileFiltering();
     testPrecisionNotTreatedAsQuantization();
     testGpt4AllCommaSizeParses();

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -49,6 +49,7 @@ const TESTS = [
     { name: 'CLI interactive panel helpers', file: 'cli-interactive-panel.test.js', category: 'UI' },
     { name: 'Windows panel overflow + resize', file: 'windows-panel-overflow.test.js', category: 'UI' },
     { name: 'Local features end-to-end', file: 'local-features-e2e.test.js', category: 'E2E' },
+    { name: 'Speed telemetry survives sync', file: 'speed-benchmark-sync-restore.test.js', category: 'Calibration' },
     { name: 'Calibration schema', file: 'calibration-schema.test.js', category: 'Calibration' },
     { name: 'Calibration command', file: 'calibrate-command.test.js', category: 'Calibration' },
     { name: 'Calibration end-to-end', file: 'calibration-e2e-integration.test.js', category: 'Calibration' },

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -7,6 +7,7 @@ const { spawnSync } = require('child_process');
 const path = require('path');
 
 const TESTS = [
+    { name: 'Parallel hardware probes', file: 'hardware-parallel-probes.test.js', category: 'Hardware' },
     { name: 'AMD GPU detection', file: 'amd-gpu-detection.test.js', category: 'Hardware' },
     { name: 'AMD Strix Halo unified memory', file: 'strix-halo-unified-memory.test.js', category: 'Hardware' },
     { name: 'CUDA Jetson detection', file: 'cuda-jetson-detection.test.js', category: 'Hardware' },

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -49,6 +49,7 @@ const TESTS = [
     { name: 'CLI interactive panel helpers', file: 'cli-interactive-panel.test.js', category: 'UI' },
     { name: 'Windows panel overflow + resize', file: 'windows-panel-overflow.test.js', category: 'UI' },
     { name: 'Local features end-to-end', file: 'local-features-e2e.test.js', category: 'E2E' },
+    { name: 'SQLite backend compatibility', file: 'database-backends.test.js', category: 'Performance' },
     { name: 'Speed telemetry survives sync', file: 'speed-benchmark-sync-restore.test.js', category: 'Calibration' },
     { name: 'Calibration schema', file: 'calibration-schema.test.js', category: 'Calibration' },
     { name: 'Calibration command', file: 'calibrate-command.test.js', category: 'Calibration' },

--- a/tests/speed-benchmark-sync-restore.test.js
+++ b/tests/speed-benchmark-sync-restore.test.js
@@ -4,6 +4,7 @@ const os = require('os');
 const path = require('path');
 
 const ModelDatabase = require('../src/data/model-database');
+const SyncManager = require('../src/data/sync-manager');
 
 async function withTempDb(fn) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-speed-restore-'));
@@ -37,24 +38,67 @@ function seedSpeedRow(database) {
 }
 
 async function run() {
+    for (const foreignKeys of [false, true]) {
+        await withTempDb(async (database) => {
+            database.run(`PRAGMA foreign_keys = ${foreignKeys ? 'ON' : 'OFF'}`);
+            const oldVariant = seedSpeedRow(database);
+            const original = database.all('SELECT * FROM benchmarks')[0];
+            const scraper = { scrapeAll: async (onModel) => {
+                onModel({ id: 'llama3', name: 'llama3' }, [{ model_id: 'llama3', tag: '8b' }]);
+            } };
+            const sync = new SyncManager({ database, scraper, onProgress() {} });
+            await sync.fullSync();
+            const variant = database.get("SELECT id FROM variants WHERE model_id = 'llama3'");
+            assert.notStrictEqual(variant.id, oldVariant.id, 'variant ids change during a rebuild');
+            assert.deepStrictEqual(database.getBenchmarks(variant.id)[0], { ...original, variant_id: variant.id });
+            database.reattachSpeedBenchmarks();
+            assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1, 'reattachment never duplicates measurements');
+
+            const beforeFailure = database.all('SELECT * FROM benchmarks');
+            scraper.scrapeAll = async () => { throw new Error('network unavailable'); };
+            await assert.rejects(sync.fullSync(), /network unavailable/);
+            assert.deepStrictEqual(database.all('SELECT * FROM benchmarks'), beforeFailure);
+            assert.strictEqual(database.getVariantCount(), 1, 'failed sync rolls the catalog back too');
+
+            scraper.scrapeAll = async () => {};
+            await sync.fullSync();
+            assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1, 'missing model keeps telemetry');
+            assert.strictEqual(database.all('SELECT * FROM benchmarks')[0].variant_id, null);
+            // Persistence matters: an in-memory snapshot is insufficient across restarts.
+            database.close(); database.db = null; database.initialized = false;
+            await database.initialize();
+            scraper.scrapeAll = async (onModel) => {
+                onModel({ id: 'llama3', name: 'llama3' }, [{ model_id: 'llama3', tag: '8b' }]);
+            };
+            await sync.fullSync();
+            const returned = database.get("SELECT id FROM variants WHERE model_id = 'llama3'");
+            assert.deepStrictEqual(database.getBenchmarks(returned.id)[0], { ...original, variant_id: returned.id });
+        });
+    }
+
     await withTempDb((database) => {
-        seedSpeedRow(database);
-        const snapshot = database.snapshotSpeedBenchmarks();
-        assert.strictEqual(snapshot.length, 1);
-
+        const variant = seedSpeedRow(database);
+        // Recreate the shipped pre-migration schema, with real historical data.
+        database.db.exec(`
+            DROP TABLE benchmarks;
+            CREATE TABLE benchmarks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, variant_id INTEGER NOT NULL,
+                hardware_fingerprint TEXT NOT NULL, tokens_per_second REAL,
+                time_to_first_token REAL, memory_used_gb REAL, backend TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE CASCADE
+            );
+            INSERT INTO benchmarks VALUES (17, ${variant.id}, 'legacy-hw', 42.5, 0.2, 5.1, 'cpu', '2026-01-01');
+        `);
+        database.migrateSpeedBenchmarks();
+        database.migrateSpeedBenchmarks();
+        const migrated = database.all('SELECT * FROM benchmarks')[0];
+        assert.strictEqual(migrated.model_id, 'llama3');
+        assert.strictEqual(migrated.tag, '8b');
+        assert.strictEqual(migrated.id, 17);
+        assert.strictEqual(migrated.created_at, '2026-01-01');
         database.clear();
-        assert.strictEqual(database.get(`SELECT COUNT(*) as count FROM benchmarks`).count, 0);
-
-        database.upsertModel({ id: 'llama3', name: 'llama3' });
-        database.upsertVariant({ model_id: 'llama3', tag: '8b' });
-        database.restoreSpeedBenchmarks(snapshot);
-        database.restoreSpeedBenchmarks(snapshot);
-
-        const restored = database.all(`SELECT tokens_per_second, hardware_fingerprint FROM benchmarks`);
-        assert.strictEqual(restored.length, 1, 'restore must replace, not append');
-        assert.strictEqual(restored[0].tokens_per_second, 42.5);
-        assert.strictEqual(restored[0].hardware_fingerprint, 'hw-1');
-        assert.strictEqual(database.snapshotSpeedBenchmarks().length, 1);
+        assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1);
     });
 
     console.log('[OK] speed-benchmark-sync-restore.test.js passed');

--- a/tests/speed-benchmark-sync-restore.test.js
+++ b/tests/speed-benchmark-sync-restore.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ModelDatabase = require('../src/data/model-database');
+
+async function withTempDb(fn) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-speed-restore-'));
+    const database = new ModelDatabase({
+        dbPath: path.join(tempDir, 'models.db'),
+        seedDbPath: path.join(tempDir, 'missing-seed.db'),
+        disableRegistrySeedImport: true
+    });
+    try {
+        await database.initialize();
+        await fn(database);
+    } finally {
+        database.close();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function seedSpeedRow(database) {
+    database.upsertModel({ id: 'llama3', name: 'llama3' });
+    database.upsertVariant({ model_id: 'llama3', tag: '8b' });
+    const variant = database.get(`SELECT id FROM variants WHERE model_id = ? AND tag = ?`, ['llama3', '8b']);
+    database.addBenchmark({
+        variant_id: variant.id,
+        hardware_fingerprint: 'hw-1',
+        tokens_per_second: 42.5,
+        time_to_first_token: 0.2,
+        memory_used_gb: 5.1,
+        backend: 'cpu'
+    });
+    return variant;
+}
+
+async function run() {
+    await withTempDb((database) => {
+        seedSpeedRow(database);
+        const snapshot = database.snapshotSpeedBenchmarks();
+        assert.strictEqual(snapshot.length, 1);
+
+        database.clear();
+        assert.strictEqual(database.get(`SELECT COUNT(*) as count FROM benchmarks`).count, 0);
+
+        database.upsertModel({ id: 'llama3', name: 'llama3' });
+        database.upsertVariant({ model_id: 'llama3', tag: '8b' });
+        database.restoreSpeedBenchmarks(snapshot);
+        database.restoreSpeedBenchmarks(snapshot);
+
+        const restored = database.all(`SELECT tokens_per_second, hardware_fingerprint FROM benchmarks`);
+        assert.strictEqual(restored.length, 1, 'restore must replace, not append');
+        assert.strictEqual(restored[0].tokens_per_second, 42.5);
+        assert.strictEqual(restored[0].hardware_fingerprint, 'hw-1');
+        assert.strictEqual(database.snapshotSpeedBenchmarks().length, 1);
+    });
+
+    console.log('[OK] speed-benchmark-sync-restore.test.js passed');
+}
+
+if (require.main === module) {
+    run().catch((error) => {
+        console.error('[FAIL] speed-benchmark-sync-restore.test.js failed');
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = { run };


### PR DESCRIPTION
Independent CPU, CUDA, ROCm, Intel and Metal probes now use asynchronous subprocesses and overlap through `Promise.all`, with per-probe timeouts. Preserve the unified hardware result contract, CPU-only behavior, platform fallbacks, and overridden synchronous detector hooks used by existing callers.

Validation: registered parallelism regression tests now rendezvous three real Node child processes (serial execution cannot complete), verify stalled subprocess termination and missing-command handling. Hardware regression, Windows CPU fallback, CPU-only, Strix Halo and model-safety suites pass. A real Ryzen 9 9900X/RTX host detection completed in 84 ms, with event-loop progress and no synchronous subprocess calls from project hardware code. The upstream systeminformation library still has two internal synchronous calls; this PR removes the project's serial probe chain.

Closes #124.
