### PR TITLE
fix: preserve local speed telemetry across catalog rebuilds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2670,9 +2670,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -4566,9 +4566,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -1178,16 +1178,65 @@ class ModelDatabase {
     }
 
     /**
-     * Clear all data
+     * Snapshot local speed telemetry keyed by model_id + tag so it can survive
+     * a force sync that recreates variant row ids.
+     */
+    snapshotSpeedBenchmarks() {
+        return this.all(`
+            SELECT v.model_id, v.tag, b.hardware_fingerprint, b.tokens_per_second,
+                   b.time_to_first_token, b.memory_used_gb, b.backend, b.created_at
+            FROM benchmarks b
+            JOIN variants v ON v.id = b.variant_id
+        `);
+    }
+
+    /**
+     * Reattach previously measured speed benchmarks to newly upserted variants.
+     * Replace, do not append: SQLite FKs are off by default so DELETE FROM
+     * variants does not cascade, and leftover rows would otherwise duplicate.
+     */
+    restoreSpeedBenchmarks(rows) {
+        this.run(`DELETE FROM benchmarks`);
+        if (!rows || rows.length === 0) return;
+
+        const insert = `
+            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second,
+                time_to_first_token, memory_used_gb, backend, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        `;
+
+        for (const row of rows) {
+            const variant = this.get(
+                `SELECT id FROM variants WHERE model_id = ? AND tag = ?`,
+                [row.model_id, row.tag]
+            );
+            if (!variant) continue;
+            this.run(insert, [
+                variant.id,
+                row.hardware_fingerprint,
+                row.tokens_per_second,
+                row.time_to_first_token,
+                row.memory_used_gb,
+                row.backend,
+                row.created_at || null
+            ]);
+        }
+    }
+
+    /**
+     * Clear catalog data. Local speed benchmarks are snapshotted by callers
+     * that recreate variants (variant_id is an autoincrement FK). Drop leftover
+     * benchmark rows here because SQLite FKs are off by default, so DELETE FROM
+     * variants does not cascade.
      */
     clear() {
         // The registry's Ollama source is derived from the local Ollama catalog.
         // Clear only that source so a classic Ollama sync does not erase HF/GPT4All data.
         this.clearRegistrySource('ollama');
-        this.run(`DELETE FROM benchmarks`);
         this.run(`DELETE FROM variants`);
         this.run(`DELETE FROM models`);
         this.run(`DELETE FROM sync_meta`);
+        this.run(`DELETE FROM benchmarks`);
     }
 
     /**

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -65,6 +65,7 @@ class ModelDatabase {
         this.useBetterSqlite = false;
 
         this.createSchema();
+        this.migrateSpeedBenchmarks();
         this.initialized = true;
         if (!this.disableRegistrySeedImport) {
             await this.seedRegistryFromPackagedSnapshotIfNeeded();
@@ -113,14 +114,16 @@ class ModelDatabase {
             -- Benchmarks table (real performance data per hardware)
             CREATE TABLE IF NOT EXISTS benchmarks (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                variant_id INTEGER NOT NULL,
+                variant_id INTEGER,
+                model_id TEXT,
+                tag TEXT,
                 hardware_fingerprint TEXT NOT NULL,
                 tokens_per_second REAL,
                 time_to_first_token REAL,
                 memory_used_gb REAL,
                 backend TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE CASCADE
+                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE SET NULL
             );
 
             -- Registry sources for multi-hub model discovery (Hugging Face,
@@ -239,6 +242,47 @@ class ModelDatabase {
         } else {
             this.db.run(schema);
             this.saveToFile();
+        }
+    }
+
+    migrateSpeedBenchmarks() {
+        if (this.all('PRAGMA table_info(benchmarks)').some((column) => column.name === 'model_id')) return;
+        // Preserve the original measurement ids/timestamps and backfill stable
+        // identities before any catalog refresh can replace variant row ids.
+        this.beginBatch();
+        try {
+            this.db.exec(`
+                SAVEPOINT migrate_speed_benchmarks;
+                CREATE TABLE benchmarks_stable (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    variant_id INTEGER,
+                    model_id TEXT,
+                    tag TEXT,
+                    hardware_fingerprint TEXT NOT NULL,
+                    tokens_per_second REAL,
+                    time_to_first_token REAL,
+                    memory_used_gb REAL,
+                    backend TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE SET NULL
+                );
+                INSERT INTO benchmarks_stable
+                SELECT b.id, v.id, v.model_id, v.tag, b.hardware_fingerprint,
+                       b.tokens_per_second, b.time_to_first_token, b.memory_used_gb,
+                       b.backend, b.created_at
+                FROM benchmarks b LEFT JOIN variants v ON v.id = b.variant_id;
+                DROP TABLE benchmarks;
+                ALTER TABLE benchmarks_stable RENAME TO benchmarks;
+                CREATE INDEX idx_benchmarks_hardware ON benchmarks(hardware_fingerprint);
+                CREATE INDEX idx_benchmarks_variant ON benchmarks(variant_id);
+                RELEASE migrate_speed_benchmarks;
+            `);
+            this._pendingSave = true;
+        } catch (error) {
+            this.db.exec('ROLLBACK TO migrate_speed_benchmarks; RELEASE migrate_speed_benchmarks;');
+            throw error;
+        } finally {
+            this.endBatch();
         }
     }
 
@@ -446,13 +490,17 @@ class ModelDatabase {
      * Add benchmark result
      */
     addBenchmark(benchmark) {
+        const variant = this.get('SELECT model_id, tag FROM variants WHERE id = ?', [benchmark.variant_id]);
+        if (!variant) throw new Error('Cannot record a benchmark for an unknown variant');
         const sql = `
-            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second, time_to_first_token, memory_used_gb, backend)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO benchmarks (variant_id, model_id, tag, hardware_fingerprint, tokens_per_second, time_to_first_token, memory_used_gb, backend)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         `;
 
         this.run(sql, [
             benchmark.variant_id,
+            variant.model_id,
+            variant.tag,
             benchmark.hardware_fingerprint,
             benchmark.tokens_per_second,
             benchmark.time_to_first_token,
@@ -1177,66 +1225,22 @@ class ModelDatabase {
         };
     }
 
-    /**
-     * Snapshot local speed telemetry keyed by model_id + tag so it can survive
-     * a force sync that recreates variant row ids.
-     */
-    snapshotSpeedBenchmarks() {
-        return this.all(`
-            SELECT v.model_id, v.tag, b.hardware_fingerprint, b.tokens_per_second,
-                   b.time_to_first_token, b.memory_used_gb, b.backend, b.created_at
-            FROM benchmarks b
-            JOIN variants v ON v.id = b.variant_id
-        `);
+    /** Reattach persisted telemetry after a catalog rebuild. Missing models keep
+     * their measurements, ready for a later sync that brings the tag back. */
+    reattachSpeedBenchmarks() {
+        this.run(`UPDATE benchmarks SET variant_id = (
+            SELECT v.id FROM variants v
+            WHERE v.model_id = benchmarks.model_id AND v.tag = benchmarks.tag
+        )`);
     }
 
-    /**
-     * Reattach previously measured speed benchmarks to newly upserted variants.
-     * Replace, do not append: SQLite FKs are off by default so DELETE FROM
-     * variants does not cascade, and leftover rows would otherwise duplicate.
-     */
-    restoreSpeedBenchmarks(rows) {
-        this.run(`DELETE FROM benchmarks`);
-        if (!rows || rows.length === 0) return;
-
-        const insert = `
-            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second,
-                time_to_first_token, memory_used_gb, backend, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-        `;
-
-        for (const row of rows) {
-            const variant = this.get(
-                `SELECT id FROM variants WHERE model_id = ? AND tag = ?`,
-                [row.model_id, row.tag]
-            );
-            if (!variant) continue;
-            this.run(insert, [
-                variant.id,
-                row.hardware_fingerprint,
-                row.tokens_per_second,
-                row.time_to_first_token,
-                row.memory_used_gb,
-                row.backend,
-                row.created_at || null
-            ]);
-        }
-    }
-
-    /**
-     * Clear catalog data. Local speed benchmarks are snapshotted by callers
-     * that recreate variants (variant_id is an autoincrement FK). Drop leftover
-     * benchmark rows here because SQLite FKs are off by default, so DELETE FROM
-     * variants does not cascade.
-     */
+    /** Clear catalog data while preserving local measurements and their keys. */
     clear() {
-        // The registry's Ollama source is derived from the local Ollama catalog.
-        // Clear only that source so a classic Ollama sync does not erase HF/GPT4All data.
         this.clearRegistrySource('ollama');
-        this.run(`DELETE FROM variants`);
-        this.run(`DELETE FROM models`);
-        this.run(`DELETE FROM sync_meta`);
-        this.run(`DELETE FROM benchmarks`);
+        this.run('UPDATE benchmarks SET variant_id = NULL');
+        this.run('DELETE FROM variants');
+        this.run('DELETE FROM models');
+        this.run('DELETE FROM sync_meta');
     }
 
     /**

--- a/src/data/registry-ingestors.js
+++ b/src/data/registry-ingestors.js
@@ -25,6 +25,22 @@ const SOURCE_DEFINITIONS = {
 const HUGGING_FACE_MODEL_API = 'https://huggingface.co/api/models';
 const GPT4ALL_MODELS_URL = 'https://gpt4all.io/models/models3.json';
 
+// A weight-file extension alone also matches diffusion models and asset bundles.
+// Require an explicit language/vision-language task, including older Hub tags.
+const LANGUAGE_MODEL_TASKS = new Set([
+    'text-generation', 'text2text-generation', 'conversational',
+    'image-text-to-text', 'image-to-text', 'visual-question-answering',
+    'document-question-answering', 'feature-extraction', 'sentence-similarity'
+]);
+
+function isSupportedHuggingFaceModel(model = {}) {
+    const library = String(model.library_name || '').toLowerCase();
+    if (/^(diffusers|diffusion-single-file|timm|peft|adapter-transformers)$/.test(library)) return false;
+    const pipeline = String(model.pipeline_tag || '').toLowerCase();
+    if (pipeline) return LANGUAGE_MODEL_TASKS.has(pipeline);
+    return toArray(model.tags).some((tag) => LANGUAGE_MODEL_TASKS.has(String(tag).toLowerCase()));
+}
+
 function extractNextLink(linkHeader = '') {
     const links = String(linkHeader || '').split(',');
     for (const link of links) {
@@ -298,7 +314,7 @@ function buildHuggingFaceDownloadUrl(repoId, filename, revision = 'main') {
 
 function normalizeHuggingFaceModel(model) {
     const repoId = model.id || model.modelId || model.model_id;
-    if (!repoId) return null;
+    if (!repoId || !isSupportedHuggingFaceModel(model)) return null;
 
     const namespace = repoId.includes('/') ? repoId.split('/')[0] : '';
     const tags = toArray(model.tags);
@@ -758,6 +774,7 @@ module.exports = {
     RegistryIngestor,
     SOURCE_DEFINITIONS,
     normalizeHuggingFaceModel,
+    isSupportedHuggingFaceModel,
     normalizeGpt4AllEntry,
     normalizeOllamaRows,
     inferFormat,

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -1,4 +1,5 @@
 const ModelDatabase = require('./model-database');
+const { isSupportedHuggingFaceModel } = require('./registry-ingestors');
 const DeterministicModelSelector = require('../models/deterministic-selector');
 const { applyCpuOnlyOverride } = require('../hardware/cpu-only');
 const { runtimeSupportedOnHardware } = require('../runtime/runtime-support');
@@ -117,6 +118,12 @@ function choosePreferredRuntime(runtimeSupport = [], format = '', sourceId = '')
 }
 
 function artifactToSelectorModel(row) {
+    // Apply the same rule to existing user databases and the packaged snapshot,
+    // so rejected repositories disappear from recommendations without a resync.
+    if (row.source_id === 'huggingface' && !isSupportedHuggingFaceModel({
+        ...(row.repo_metadata || {}),
+        tags: [...toArray(row.repo_tags), ...toArray(row.repo_tasks), ...toArray(row.tasks)]
+    })) return null;
     const shardedFile = row.source_id === 'huggingface' && isShardedWeightFile(row.filename || row.artifact_name);
     const identifier = shardedFile
         ? (row.canonical_model_id || row.repo_id)

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -590,7 +590,9 @@ class RegistryRecommender {
                     bestModels: selection.result.candidates.map((candidate) => this.selector.mapCandidateToLegacyFormat(candidate)),
                     totalEvaluated: selection.result.total_evaluated,
                     totalArtifacts: selection.rows.length,
-                    totalCandidates: selection.modelPool.length,
+                    // Public category headers use this field as "evaluated".
+                    // The unfiltered catalog pool is shared by every category.
+                    totalCandidates: selection.result.total_evaluated,
                     category: this.selector.getCategoryInfo(category)
                 };
             } catch (error) {
@@ -641,6 +643,7 @@ class RegistryRecommender {
         const budget = isUnified ? usableMem : (vram || usableMem);
         const filtered = this.selector.filterByCategory(modelPool, category, { includeUncensored });
         const candidates = [];
+        let totalEvaluated = 0;
 
         for (const model of filtered) {
             const preferredRuntime = model.preferredRuntime || choosePreferredRuntime(
@@ -656,6 +659,7 @@ class RegistryRecommender {
                 runtimeSupportedOnHardware(candidateRuntime, normalizedHardware)
             );
             if (!runtime) continue;
+            totalEvaluated += 1;
             const candidate = this.selector.evaluateModel(
                 model,
                 normalizedHardware,
@@ -678,7 +682,7 @@ class RegistryRecommender {
             // Return a wide sorted window; selectCategory collapses variants and
             // applies source diversity before trimming to the caller's limit.
             candidates: candidates.slice(0, Math.max(limit, 2000)),
-            total_evaluated: filtered.length,
+            total_evaluated: totalEvaluated,
             timestamp: new Date().toISOString()
         };
     }

--- a/src/data/sync-manager.js
+++ b/src/data/sync-manager.js
@@ -52,7 +52,11 @@ class SyncManager {
         // times, turning the sync into O(n^2) disk I/O.
         this.db.beginBatch();
         try {
-            // Clear existing data
+            // Keep locally measured speed telemetry across force sync.
+            const speedBenchmarks = this.db.snapshotSpeedBenchmarks();
+
+            // Clear existing catalog data (variants/models). Benchmarks are
+            // re-keyed onto new variant ids after upsert.
             this.db.clear();
 
             // Scrape all models
@@ -62,6 +66,8 @@ class SyncManager {
                     this.db.upsertVariant(variant);
                 }
             });
+
+            this.db.restoreSpeedBenchmarks(speedBenchmarks);
 
             // Update sync timestamp
             this.db.setLastSync(new Date().toISOString());

--- a/src/data/sync-manager.js
+++ b/src/data/sync-manager.js
@@ -52,11 +52,9 @@ class SyncManager {
         // times, turning the sync into O(n^2) disk I/O.
         this.db.beginBatch();
         try {
-            // Keep locally measured speed telemetry across force sync.
-            const speedBenchmarks = this.db.snapshotSpeedBenchmarks();
-
-            // Clear existing catalog data (variants/models). Benchmarks are
-            // re-keyed onto new variant ids after upsert.
+            this.db.run('SAVEPOINT full_sync');
+            // Stable model/tag keys keep telemetry even when a model temporarily
+            // disappears from the catalog. Roll back failed refreshes as a unit.
             this.db.clear();
 
             // Scrape all models
@@ -67,10 +65,15 @@ class SyncManager {
                 }
             });
 
-            this.db.restoreSpeedBenchmarks(speedBenchmarks);
+            this.db.reattachSpeedBenchmarks();
 
             // Update sync timestamp
             this.db.setLastSync(new Date().toISOString());
+            this.db.run('RELEASE full_sync');
+        } catch (error) {
+            this.db.run('ROLLBACK TO full_sync');
+            this.db.run('RELEASE full_sync');
+            throw error;
         } finally {
             this.db.endBatch();
         }

--- a/tests/model-registry-param-parsing.test.js
+++ b/tests/model-registry-param-parsing.test.js
@@ -39,6 +39,7 @@ function testContextTokenNotMisreadAsParams() {
 function testRecommenderMoEParsing() {
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         source_name: 'Hugging Face Hub',
         repo_id: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
         canonical_model_id: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
@@ -55,6 +56,7 @@ function testRecommenderActiveParamTotalSizing() {
     // "397B-A17B" = 397B total / 17B active. Memory must be sized by the TOTAL.
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B'
@@ -71,6 +73,7 @@ function testRecommenderActiveParamTotalSizing() {
     // parameter_count_b, the name re-derivation must still size it as 397B.
     const stale = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B',
@@ -85,6 +88,7 @@ function testHugeMoEDoesNotFitSmallHardware() {
     const selector = new DeterministicModelSelector();
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B',
@@ -149,6 +153,7 @@ function testShardedFileSizeNotUsedAsModelSize() {
     // whose shard is 4.66GB must be sized from params, not "fit" as 4.66GB.
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'org/Big-56B',
         canonical_model_id: 'org/Big-56B',
         artifact_name: 'model-00001-of-00012.safetensors',

--- a/tests/model-registry-recommender.test.js
+++ b/tests/model-registry-recommender.test.js
@@ -151,6 +151,29 @@ async function run() {
         assert.ok(['vllm', 'transformers'].includes(hfResult.recommendations[0].runtime));
         assert.ok(hfResult.recommendations[0].download_url.includes('huggingface.co/example/CodeTiny-7B'));
 
+        // Count actual scoring calls: headers must describe each category, even
+        // when most candidates fail to fit or an entire category is empty.
+        const evaluateModel = recommender.selector.evaluateModel;
+        const calls = {};
+        recommender.selector.evaluateModel = function(model, hardware, category, ...args) {
+            calls[category] = (calls[category] || 0) + 1;
+            return evaluateModel.call(this, model, hardware, category, ...args);
+        };
+        for (const runtime of ['auto', 'ollama']) {
+            for (const key of Object.keys(calls)) delete calls[key];
+            const grouped = await recommender.getBestModelsForHardware(buildHardware(), {
+                runtime, categories: ['general', 'coding', 'multimodal'], limit: 1
+            });
+            for (const [category, group] of Object.entries(grouped.recommendations)) {
+                assert.strictEqual(group.totalCandidates, calls[category] || 0, `${runtime}/${category} header`);
+                assert.strictEqual(group.totalEvaluated, calls[category] || 0);
+            }
+            assert.ok(grouped.recommendations.general.totalCandidates > grouped.recommendations.coding.totalCandidates);
+            assert.strictEqual(grouped.recommendations.multimodal.totalCandidates, 0);
+            assert.ok(grouped.totalModelsAnalyzed > 0, 'global pool remains available separately');
+        }
+        recommender.selector.evaluateModel = evaluateModel;
+
         console.log('[OK] model-registry-recommender.test.js passed');
     } finally {
         database.close();

--- a/tests/model-registry-seed.test.js
+++ b/tests/model-registry-seed.test.js
@@ -7,9 +7,10 @@ const ModelDatabase = require('../src/data/model-database');
 
 async function run() {
     const seedDbPath = path.join(__dirname, '..', 'src', 'data', 'seed', 'models.db');
+    const seedTestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-seed-test-'));
     const database = new ModelDatabase({
-        dbPath: seedDbPath,
-        seedDbPath: path.join(__dirname, 'missing-seed.db')
+        dbPath: path.join(seedTestDir, 'models.db'),
+        seedDbPath
     });
 
     try {
@@ -68,6 +69,7 @@ async function run() {
         console.log('[OK] model-registry-seed.test.js passed');
     } finally {
         database.close();
+        fs.rmSync(seedTestDir, { recursive: true, force: true });
     }
 }
 

--- a/tests/registry-ingestor-quality.test.js
+++ b/tests/registry-ingestor-quality.test.js
@@ -11,9 +11,39 @@
 const assert = require('assert');
 const {
     isModelArtifactFile,
+    normalizeHuggingFaceModel,
     inferQuantization,
     normalizeGpt4AllEntry
 } = require('../src/data/registry-ingestors');
+const { artifactToSelectorModel } = require('../src/data/registry-recommender');
+
+function testLanguageModelRepositoryFiltering() {
+    const weights = [{ rfilename: 'model.safetensors', size: 4e9 }];
+    for (const model of [
+        { id: 'UmeAiRT/ComfyUI-Auto-Installer-Assets', library_name: 'diffusers', tags: ['gguf', 'comfyui'] },
+        { id: 'Kijai/WanVideo_comfy', library_name: 'diffusion-single-file' },
+        { id: 'org/video-7B', pipeline_tag: 'text-to-video', tags: ['text-generation'] },
+        { id: 'org/unknown-7B', tags: ['safetensors'] },
+        { id: 'org/adapter-7B', pipeline_tag: 'text-generation', library_name: 'peft' }
+    ]) {
+        assert.strictEqual(normalizeHuggingFaceModel({ ...model, siblings: weights }), null, model.id);
+        assert.strictEqual(artifactToSelectorModel({
+            source_id: 'huggingface', repo_id: model.id, parameter_count_b: 7,
+            artifact_name: 'model.safetensors', repo_metadata: model, repo_tags: model.tags
+        }), null, `cached ${model.id} must also be rejected`);
+    }
+    for (const task of ['text-generation', 'image-text-to-text', 'feature-extraction', 'sentence-similarity']) {
+        const model = { id: 'org/valid-7B', pipeline_tag: task, siblings: weights };
+        assert.strictEqual(normalizeHuggingFaceModel(model).artifacts.length, 1);
+        assert.ok(artifactToSelectorModel({
+            source_id: 'huggingface', repo_id: model.id, parameter_count_b: 7,
+            artifact_name: 'model.safetensors', repo_metadata: model
+        }));
+    }
+    assert.ok(normalizeHuggingFaceModel({
+        id: 'org/legacy-7B-GGUF', tags: ['gguf', 'text-generation'], siblings: weights
+    }), 'legacy task tags remain supported');
+}
 
 function testArtifactFileFiltering() {
     // Real model weights -> included
@@ -61,6 +91,7 @@ function testGpt4AllCanonicalFromHfRepo() {
 }
 
 function run() {
+    testLanguageModelRepositoryFiltering();
     testArtifactFileFiltering();
     testPrecisionNotTreatedAsQuantization();
     testGpt4AllCommaSizeParses();

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -49,6 +49,7 @@ const TESTS = [
     { name: 'CLI interactive panel helpers', file: 'cli-interactive-panel.test.js', category: 'UI' },
     { name: 'Windows panel overflow + resize', file: 'windows-panel-overflow.test.js', category: 'UI' },
     { name: 'Local features end-to-end', file: 'local-features-e2e.test.js', category: 'E2E' },
+    { name: 'Speed telemetry survives sync', file: 'speed-benchmark-sync-restore.test.js', category: 'Calibration' },
     { name: 'Calibration schema', file: 'calibration-schema.test.js', category: 'Calibration' },
     { name: 'Calibration command', file: 'calibrate-command.test.js', category: 'Calibration' },
     { name: 'Calibration end-to-end', file: 'calibration-e2e-integration.test.js', category: 'Calibration' },

--- a/tests/speed-benchmark-sync-restore.test.js
+++ b/tests/speed-benchmark-sync-restore.test.js
@@ -4,6 +4,7 @@ const os = require('os');
 const path = require('path');
 
 const ModelDatabase = require('../src/data/model-database');
+const SyncManager = require('../src/data/sync-manager');
 
 async function withTempDb(fn) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-speed-restore-'));
@@ -37,24 +38,67 @@ function seedSpeedRow(database) {
 }
 
 async function run() {
+    for (const foreignKeys of [false, true]) {
+        await withTempDb(async (database) => {
+            database.run(`PRAGMA foreign_keys = ${foreignKeys ? 'ON' : 'OFF'}`);
+            const oldVariant = seedSpeedRow(database);
+            const original = database.all('SELECT * FROM benchmarks')[0];
+            const scraper = { scrapeAll: async (onModel) => {
+                onModel({ id: 'llama3', name: 'llama3' }, [{ model_id: 'llama3', tag: '8b' }]);
+            } };
+            const sync = new SyncManager({ database, scraper, onProgress() {} });
+            await sync.fullSync();
+            const variant = database.get("SELECT id FROM variants WHERE model_id = 'llama3'");
+            assert.notStrictEqual(variant.id, oldVariant.id, 'variant ids change during a rebuild');
+            assert.deepStrictEqual(database.getBenchmarks(variant.id)[0], { ...original, variant_id: variant.id });
+            database.reattachSpeedBenchmarks();
+            assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1, 'reattachment never duplicates measurements');
+
+            const beforeFailure = database.all('SELECT * FROM benchmarks');
+            scraper.scrapeAll = async () => { throw new Error('network unavailable'); };
+            await assert.rejects(sync.fullSync(), /network unavailable/);
+            assert.deepStrictEqual(database.all('SELECT * FROM benchmarks'), beforeFailure);
+            assert.strictEqual(database.getVariantCount(), 1, 'failed sync rolls the catalog back too');
+
+            scraper.scrapeAll = async () => {};
+            await sync.fullSync();
+            assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1, 'missing model keeps telemetry');
+            assert.strictEqual(database.all('SELECT * FROM benchmarks')[0].variant_id, null);
+            // Persistence matters: an in-memory snapshot is insufficient across restarts.
+            database.close(); database.db = null; database.initialized = false;
+            await database.initialize();
+            scraper.scrapeAll = async (onModel) => {
+                onModel({ id: 'llama3', name: 'llama3' }, [{ model_id: 'llama3', tag: '8b' }]);
+            };
+            await sync.fullSync();
+            const returned = database.get("SELECT id FROM variants WHERE model_id = 'llama3'");
+            assert.deepStrictEqual(database.getBenchmarks(returned.id)[0], { ...original, variant_id: returned.id });
+        });
+    }
+
     await withTempDb((database) => {
-        seedSpeedRow(database);
-        const snapshot = database.snapshotSpeedBenchmarks();
-        assert.strictEqual(snapshot.length, 1);
-
+        const variant = seedSpeedRow(database);
+        // Recreate the shipped pre-migration schema, with real historical data.
+        database.db.exec(`
+            DROP TABLE benchmarks;
+            CREATE TABLE benchmarks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, variant_id INTEGER NOT NULL,
+                hardware_fingerprint TEXT NOT NULL, tokens_per_second REAL,
+                time_to_first_token REAL, memory_used_gb REAL, backend TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE CASCADE
+            );
+            INSERT INTO benchmarks VALUES (17, ${variant.id}, 'legacy-hw', 42.5, 0.2, 5.1, 'cpu', '2026-01-01');
+        `);
+        database.migrateSpeedBenchmarks();
+        database.migrateSpeedBenchmarks();
+        const migrated = database.all('SELECT * FROM benchmarks')[0];
+        assert.strictEqual(migrated.model_id, 'llama3');
+        assert.strictEqual(migrated.tag, '8b');
+        assert.strictEqual(migrated.id, 17);
+        assert.strictEqual(migrated.created_at, '2026-01-01');
         database.clear();
-        assert.strictEqual(database.get(`SELECT COUNT(*) as count FROM benchmarks`).count, 0);
-
-        database.upsertModel({ id: 'llama3', name: 'llama3' });
-        database.upsertVariant({ model_id: 'llama3', tag: '8b' });
-        database.restoreSpeedBenchmarks(snapshot);
-        database.restoreSpeedBenchmarks(snapshot);
-
-        const restored = database.all(`SELECT tokens_per_second, hardware_fingerprint FROM benchmarks`);
-        assert.strictEqual(restored.length, 1, 'restore must replace, not append');
-        assert.strictEqual(restored[0].tokens_per_second, 42.5);
-        assert.strictEqual(restored[0].hardware_fingerprint, 'hw-1');
-        assert.strictEqual(database.snapshotSpeedBenchmarks().length, 1);
+        assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1);
     });
 
     console.log('[OK] speed-benchmark-sync-restore.test.js passed');

--- a/tests/speed-benchmark-sync-restore.test.js
+++ b/tests/speed-benchmark-sync-restore.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ModelDatabase = require('../src/data/model-database');
+
+async function withTempDb(fn) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-speed-restore-'));
+    const database = new ModelDatabase({
+        dbPath: path.join(tempDir, 'models.db'),
+        seedDbPath: path.join(tempDir, 'missing-seed.db'),
+        disableRegistrySeedImport: true
+    });
+    try {
+        await database.initialize();
+        await fn(database);
+    } finally {
+        database.close();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function seedSpeedRow(database) {
+    database.upsertModel({ id: 'llama3', name: 'llama3' });
+    database.upsertVariant({ model_id: 'llama3', tag: '8b' });
+    const variant = database.get(`SELECT id FROM variants WHERE model_id = ? AND tag = ?`, ['llama3', '8b']);
+    database.addBenchmark({
+        variant_id: variant.id,
+        hardware_fingerprint: 'hw-1',
+        tokens_per_second: 42.5,
+        time_to_first_token: 0.2,
+        memory_used_gb: 5.1,
+        backend: 'cpu'
+    });
+    return variant;
+}
+
+async function run() {
+    await withTempDb((database) => {
+        seedSpeedRow(database);
+        const snapshot = database.snapshotSpeedBenchmarks();
+        assert.strictEqual(snapshot.length, 1);
+
+        database.clear();
+        assert.strictEqual(database.get(`SELECT COUNT(*) as count FROM benchmarks`).count, 0);
+
+        database.upsertModel({ id: 'llama3', name: 'llama3' });
+        database.upsertVariant({ model_id: 'llama3', tag: '8b' });
+        database.restoreSpeedBenchmarks(snapshot);
+        database.restoreSpeedBenchmarks(snapshot);
+
+        const restored = database.all(`SELECT tokens_per_second, hardware_fingerprint FROM benchmarks`);
+        assert.strictEqual(restored.length, 1, 'restore must replace, not append');
+        assert.strictEqual(restored[0].tokens_per_second, 42.5);
+        assert.strictEqual(restored[0].hardware_fingerprint, 'hw-1');
+        assert.strictEqual(database.snapshotSpeedBenchmarks().length, 1);
+    });
+
+    console.log('[OK] speed-benchmark-sync-restore.test.js passed');
+}
+
+if (require.main === module) {
+    run().catch((error) => {
+        console.error('[FAIL] speed-benchmark-sync-restore.test.js failed');
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = { run };


### PR DESCRIPTION
`sync --force` erased locally measured speed telemetry when it rebuilt variant ids. Benchmarks now retain stable model/tag identities, and existing databases migrate without losing measurement ids, timestamps or values. A refresh reattaches measurements to new variants; missing models retain their history across process restarts. Failed refreshes roll back both catalog and telemetry.

Validation: registered regression suite covers successful refresh, network failure, disappearing/reappearing models, persistence across reopen, idempotence, legacy schema migration and foreign keys both enabled and disabled. Registry ingestion and packaged-seed tests pass. Live Ollama scraping found 239 models; refreshed TinyLlama's 36 variants twice and verified the stored measurement survived while its variant id changed from 5 to 41.

Closes #122.
