### PR TITLE
fix: report category-specific model evaluation counts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2670,9 +2670,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -4566,9 +4566,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/src/data/registry-ingestors.js
+++ b/src/data/registry-ingestors.js
@@ -25,6 +25,22 @@ const SOURCE_DEFINITIONS = {
 const HUGGING_FACE_MODEL_API = 'https://huggingface.co/api/models';
 const GPT4ALL_MODELS_URL = 'https://gpt4all.io/models/models3.json';
 
+// A weight-file extension alone also matches diffusion models and asset bundles.
+// Require an explicit language/vision-language task, including older Hub tags.
+const LANGUAGE_MODEL_TASKS = new Set([
+    'text-generation', 'text2text-generation', 'conversational',
+    'image-text-to-text', 'image-to-text', 'visual-question-answering',
+    'document-question-answering', 'feature-extraction', 'sentence-similarity'
+]);
+
+function isSupportedHuggingFaceModel(model = {}) {
+    const library = String(model.library_name || '').toLowerCase();
+    if (/^(diffusers|diffusion-single-file|timm|peft|adapter-transformers)$/.test(library)) return false;
+    const pipeline = String(model.pipeline_tag || '').toLowerCase();
+    if (pipeline) return LANGUAGE_MODEL_TASKS.has(pipeline);
+    return toArray(model.tags).some((tag) => LANGUAGE_MODEL_TASKS.has(String(tag).toLowerCase()));
+}
+
 function extractNextLink(linkHeader = '') {
     const links = String(linkHeader || '').split(',');
     for (const link of links) {
@@ -298,7 +314,7 @@ function buildHuggingFaceDownloadUrl(repoId, filename, revision = 'main') {
 
 function normalizeHuggingFaceModel(model) {
     const repoId = model.id || model.modelId || model.model_id;
-    if (!repoId) return null;
+    if (!repoId || !isSupportedHuggingFaceModel(model)) return null;
 
     const namespace = repoId.includes('/') ? repoId.split('/')[0] : '';
     const tags = toArray(model.tags);
@@ -758,6 +774,7 @@ module.exports = {
     RegistryIngestor,
     SOURCE_DEFINITIONS,
     normalizeHuggingFaceModel,
+    isSupportedHuggingFaceModel,
     normalizeGpt4AllEntry,
     normalizeOllamaRows,
     inferFormat,

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -1,4 +1,5 @@
 const ModelDatabase = require('./model-database');
+const { isSupportedHuggingFaceModel } = require('./registry-ingestors');
 const DeterministicModelSelector = require('../models/deterministic-selector');
 const { applyCpuOnlyOverride } = require('../hardware/cpu-only');
 const { runtimeSupportedOnHardware } = require('../runtime/runtime-support');
@@ -117,6 +118,12 @@ function choosePreferredRuntime(runtimeSupport = [], format = '', sourceId = '')
 }
 
 function artifactToSelectorModel(row) {
+    // Apply the same rule to existing user databases and the packaged snapshot,
+    // so rejected repositories disappear from recommendations without a resync.
+    if (row.source_id === 'huggingface' && !isSupportedHuggingFaceModel({
+        ...(row.repo_metadata || {}),
+        tags: [...toArray(row.repo_tags), ...toArray(row.repo_tasks), ...toArray(row.tasks)]
+    })) return null;
     const shardedFile = row.source_id === 'huggingface' && isShardedWeightFile(row.filename || row.artifact_name);
     const identifier = shardedFile
         ? (row.canonical_model_id || row.repo_id)

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -590,7 +590,9 @@ class RegistryRecommender {
                     bestModels: selection.result.candidates.map((candidate) => this.selector.mapCandidateToLegacyFormat(candidate)),
                     totalEvaluated: selection.result.total_evaluated,
                     totalArtifacts: selection.rows.length,
-                    totalCandidates: selection.modelPool.length,
+                    // Public category headers use this field as "evaluated".
+                    // The unfiltered catalog pool is shared by every category.
+                    totalCandidates: selection.result.total_evaluated,
                     category: this.selector.getCategoryInfo(category)
                 };
             } catch (error) {
@@ -641,6 +643,7 @@ class RegistryRecommender {
         const budget = isUnified ? usableMem : (vram || usableMem);
         const filtered = this.selector.filterByCategory(modelPool, category, { includeUncensored });
         const candidates = [];
+        let totalEvaluated = 0;
 
         for (const model of filtered) {
             const preferredRuntime = model.preferredRuntime || choosePreferredRuntime(
@@ -656,6 +659,7 @@ class RegistryRecommender {
                 runtimeSupportedOnHardware(candidateRuntime, normalizedHardware)
             );
             if (!runtime) continue;
+            totalEvaluated += 1;
             const candidate = this.selector.evaluateModel(
                 model,
                 normalizedHardware,
@@ -678,7 +682,7 @@ class RegistryRecommender {
             // Return a wide sorted window; selectCategory collapses variants and
             // applies source diversity before trimming to the caller's limit.
             candidates: candidates.slice(0, Math.max(limit, 2000)),
-            total_evaluated: filtered.length,
+            total_evaluated: totalEvaluated,
             timestamp: new Date().toISOString()
         };
     }

--- a/tests/model-registry-param-parsing.test.js
+++ b/tests/model-registry-param-parsing.test.js
@@ -39,6 +39,7 @@ function testContextTokenNotMisreadAsParams() {
 function testRecommenderMoEParsing() {
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         source_name: 'Hugging Face Hub',
         repo_id: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
         canonical_model_id: 'mistralai/Mixtral-8x7B-Instruct-v0.1',
@@ -55,6 +56,7 @@ function testRecommenderActiveParamTotalSizing() {
     // "397B-A17B" = 397B total / 17B active. Memory must be sized by the TOTAL.
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B'
@@ -71,6 +73,7 @@ function testRecommenderActiveParamTotalSizing() {
     // parameter_count_b, the name re-derivation must still size it as 397B.
     const stale = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B',
@@ -85,6 +88,7 @@ function testHugeMoEDoesNotFitSmallHardware() {
     const selector = new DeterministicModelSelector();
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'Qwen/Qwen3-397B-A17B',
         canonical_model_id: 'Qwen/Qwen3-397B-A17B',
         artifact_name: 'Qwen3-397B-A17B',
@@ -149,6 +153,7 @@ function testShardedFileSizeNotUsedAsModelSize() {
     // whose shard is 4.66GB must be sized from params, not "fit" as 4.66GB.
     const model = artifactToSelectorModel({
         source_id: 'huggingface',
+        tasks: ['text-generation'],
         repo_id: 'org/Big-56B',
         canonical_model_id: 'org/Big-56B',
         artifact_name: 'model-00001-of-00012.safetensors',

--- a/tests/model-registry-recommender.test.js
+++ b/tests/model-registry-recommender.test.js
@@ -151,6 +151,29 @@ async function run() {
         assert.ok(['vllm', 'transformers'].includes(hfResult.recommendations[0].runtime));
         assert.ok(hfResult.recommendations[0].download_url.includes('huggingface.co/example/CodeTiny-7B'));
 
+        // Count actual scoring calls: headers must describe each category, even
+        // when most candidates fail to fit or an entire category is empty.
+        const evaluateModel = recommender.selector.evaluateModel;
+        const calls = {};
+        recommender.selector.evaluateModel = function(model, hardware, category, ...args) {
+            calls[category] = (calls[category] || 0) + 1;
+            return evaluateModel.call(this, model, hardware, category, ...args);
+        };
+        for (const runtime of ['auto', 'ollama']) {
+            for (const key of Object.keys(calls)) delete calls[key];
+            const grouped = await recommender.getBestModelsForHardware(buildHardware(), {
+                runtime, categories: ['general', 'coding', 'multimodal'], limit: 1
+            });
+            for (const [category, group] of Object.entries(grouped.recommendations)) {
+                assert.strictEqual(group.totalCandidates, calls[category] || 0, `${runtime}/${category} header`);
+                assert.strictEqual(group.totalEvaluated, calls[category] || 0);
+            }
+            assert.ok(grouped.recommendations.general.totalCandidates > grouped.recommendations.coding.totalCandidates);
+            assert.strictEqual(grouped.recommendations.multimodal.totalCandidates, 0);
+            assert.ok(grouped.totalModelsAnalyzed > 0, 'global pool remains available separately');
+        }
+        recommender.selector.evaluateModel = evaluateModel;
+
         console.log('[OK] model-registry-recommender.test.js passed');
     } finally {
         database.close();

--- a/tests/registry-ingestor-quality.test.js
+++ b/tests/registry-ingestor-quality.test.js
@@ -11,9 +11,39 @@
 const assert = require('assert');
 const {
     isModelArtifactFile,
+    normalizeHuggingFaceModel,
     inferQuantization,
     normalizeGpt4AllEntry
 } = require('../src/data/registry-ingestors');
+const { artifactToSelectorModel } = require('../src/data/registry-recommender');
+
+function testLanguageModelRepositoryFiltering() {
+    const weights = [{ rfilename: 'model.safetensors', size: 4e9 }];
+    for (const model of [
+        { id: 'UmeAiRT/ComfyUI-Auto-Installer-Assets', library_name: 'diffusers', tags: ['gguf', 'comfyui'] },
+        { id: 'Kijai/WanVideo_comfy', library_name: 'diffusion-single-file' },
+        { id: 'org/video-7B', pipeline_tag: 'text-to-video', tags: ['text-generation'] },
+        { id: 'org/unknown-7B', tags: ['safetensors'] },
+        { id: 'org/adapter-7B', pipeline_tag: 'text-generation', library_name: 'peft' }
+    ]) {
+        assert.strictEqual(normalizeHuggingFaceModel({ ...model, siblings: weights }), null, model.id);
+        assert.strictEqual(artifactToSelectorModel({
+            source_id: 'huggingface', repo_id: model.id, parameter_count_b: 7,
+            artifact_name: 'model.safetensors', repo_metadata: model, repo_tags: model.tags
+        }), null, `cached ${model.id} must also be rejected`);
+    }
+    for (const task of ['text-generation', 'image-text-to-text', 'feature-extraction', 'sentence-similarity']) {
+        const model = { id: 'org/valid-7B', pipeline_tag: task, siblings: weights };
+        assert.strictEqual(normalizeHuggingFaceModel(model).artifacts.length, 1);
+        assert.ok(artifactToSelectorModel({
+            source_id: 'huggingface', repo_id: model.id, parameter_count_b: 7,
+            artifact_name: 'model.safetensors', repo_metadata: model
+        }));
+    }
+    assert.ok(normalizeHuggingFaceModel({
+        id: 'org/legacy-7B-GGUF', tags: ['gguf', 'text-generation'], siblings: weights
+    }), 'legacy task tags remain supported');
+}
 
 function testArtifactFileFiltering() {
     // Real model weights -> included
@@ -61,6 +91,7 @@ function testGpt4AllCanonicalFromHfRepo() {
 }
 
 function run() {
+    testLanguageModelRepositoryFiltering();
     testArtifactFileFiltering();
     testPrecisionNotTreatedAsQuantization();
     testGpt4AllCommaSizeParses();


### PR DESCRIPTION
Category headers repeated the entire registry pool size in `totalCandidates`. They now report the number actually evaluated for that category, consistent with `totalEvaluated`. Auto runtime selection excludes models with no supported runtime from this count; catalog totals remain available separately.

Validation: regression test counts real scoring calls for auto and explicit Ollama runtimes, including an empty vision category. Ran the recommender with detected host hardware and the packaged database: coding 1,506; reasoning 6,012; vision 1,350; general/chat/creative/reading 8,161. Equal counts remain valid where categories share the same eligibility rules.

Closes #121.
