### PR TITLE
perf: use native SQLite with an older-Node WASM fallback

### DIFF
--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -12,6 +12,10 @@ class ModelDatabase {
         this.dbPath = options.dbPath || path.join(os.homedir(), '.llm-checker', 'models.db');
         this.seedDbPath = options.seedDbPath || path.join(__dirname, 'seed', 'models.db');
         this.db = null;
+        this.sqliteBackend = options.sqliteBackend || 'auto';
+        if (!['auto', 'native', 'wasm'].includes(this.sqliteBackend)) {
+            throw new Error(`Unknown SQLite backend: ${this.sqliteBackend}`);
+        }
         this.initialized = false;
         this.disableRegistrySeedImport = Boolean(options.disableRegistrySeedImport);
         // Batched-write state: during a bulk sync we defer the (expensive) full
@@ -46,23 +50,34 @@ class ModelDatabase {
         }
         this.seedDatabaseIfNeeded();
 
-        // Use sql.js (optional dependency)
-        let initSqlJs;
-        try {
-            initSqlJs = require('sql.js');
-        } catch (e) {
-            throw new Error('sql.js is not installed. Install it with: npm install sql.js');
+        let DatabaseSync;
+        if (this.sqliteBackend !== 'wasm') {
+            try {
+                ({ DatabaseSync } = require('node:sqlite'));
+            } catch (error) {
+                if (this.sqliteBackend === 'native' || !['ERR_UNKNOWN_BUILTIN_MODULE', 'MODULE_NOT_FOUND'].includes(error.code)) {
+                    throw error;
+                }
+            }
         }
-        const SQL = await initSqlJs();
-
-        // Load existing database or create new
-        if (fs.existsSync(this.dbPath)) {
-            const buffer = fs.readFileSync(this.dbPath);
-            this.db = new SQL.Database(buffer);
+        this.useNativeSqlite = Boolean(DatabaseSync);
+        if (DatabaseSync) {
+            // Keep the file on disk; do not allocate a WASM heap or read it all.
+            // Opening errors must surface, rather than retrying with another engine.
+            this.db = new DatabaseSync(this.dbPath);
+            this.db.exec('PRAGMA busy_timeout = 5000');
         } else {
-            this.db = new SQL.Database();
+            let initSqlJs;
+            try {
+                initSqlJs = require('sql.js');
+            } catch {
+                throw new Error('This Node version requires sql.js. Install it with: npm install sql.js');
+            }
+            const SQL = await initSqlJs();
+            this.db = fs.existsSync(this.dbPath)
+                ? new SQL.Database(fs.readFileSync(this.dbPath))
+                : new SQL.Database();
         }
-        this.useBetterSqlite = false;
 
         this.createSchema();
         this.migrateSpeedBenchmarks();
@@ -237,7 +252,7 @@ class ModelDatabase {
             DROP INDEX IF EXISTS idx_model_artifacts_runtime;
         `;
 
-        if (this.useBetterSqlite) {
+        if (this.useNativeSqlite) {
             this.db.exec(schema);
         } else {
             this.db.run(schema);
@@ -290,7 +305,7 @@ class ModelDatabase {
      * Save sql.js database to file
      */
     saveToFile() {
-        if (!this.useBetterSqlite && this.db) {
+        if (!this.useNativeSqlite && this.db) {
             const data = this.db.export();
             const buffer = Buffer.from(data);
             // Write to a temp file then atomically rename, so a crash/SIGINT
@@ -307,12 +322,19 @@ class ModelDatabase {
      * instead of on every row. Nestable; the outermost endBatch() flushes.
      */
     beginBatch() {
+        if (this.useNativeSqlite && this._batchDepth === 0) {
+            this.db.exec('SAVEPOINT llm_checker_batch');
+        }
         this._batchDepth += 1;
     }
 
     endBatch() {
         if (this._batchDepth > 0) {
             this._batchDepth -= 1;
+            if (this.useNativeSqlite && this._batchDepth === 0) {
+                this.db.exec('RELEASE llm_checker_batch');
+                this._pendingSave = false;
+            }
         }
         if (this._batchDepth === 0 && this._pendingSave) {
             this.saveToFile();
@@ -323,7 +345,7 @@ class ModelDatabase {
      * Execute a query (handles both sqlite implementations)
      */
     run(sql, params = []) {
-        if (this.useBetterSqlite) {
+        if (this.useNativeSqlite) {
             return this.db.prepare(sql).run(...params);
         } else {
             this.db.run(sql, params);
@@ -339,8 +361,8 @@ class ModelDatabase {
      * Get all results from a query
      */
     all(sql, params = []) {
-        if (this.useBetterSqlite) {
-            return this.db.prepare(sql).all(...params);
+        if (this.useNativeSqlite) {
+            return this.db.prepare(sql).all(...params).map((row) => ({ ...row }));
         } else {
             const stmt = this.db.prepare(sql);
             stmt.bind(params);
@@ -357,8 +379,9 @@ class ModelDatabase {
      * Get single result from a query
      */
     get(sql, params = []) {
-        if (this.useBetterSqlite) {
-            return this.db.prepare(sql).get(...params);
+        if (this.useNativeSqlite) {
+            const row = this.db.prepare(sql).get(...params);
+            return row ? { ...row } : null;
         } else {
             const results = this.all(sql, params);
             return results.length > 0 ? results[0] : null;
@@ -1263,14 +1286,12 @@ class ModelDatabase {
      * Close database connection
      */
     close() {
-        if (this.db) {
-            if (this.useBetterSqlite) {
-                this.db.close();
-            } else {
-                this.saveToFile();
-                this.db.close();
-            }
-        }
+        if (!this.db) return;
+        while (this._batchDepth > 0) this.endBatch();
+        if (!this.useNativeSqlite) this.saveToFile();
+        this.db.close();
+        this.db = null;
+        this.initialized = false;
     }
 }
 

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -1178,16 +1178,65 @@ class ModelDatabase {
     }
 
     /**
-     * Clear all data
+     * Snapshot local speed telemetry keyed by model_id + tag so it can survive
+     * a force sync that recreates variant row ids.
+     */
+    snapshotSpeedBenchmarks() {
+        return this.all(`
+            SELECT v.model_id, v.tag, b.hardware_fingerprint, b.tokens_per_second,
+                   b.time_to_first_token, b.memory_used_gb, b.backend, b.created_at
+            FROM benchmarks b
+            JOIN variants v ON v.id = b.variant_id
+        `);
+    }
+
+    /**
+     * Reattach previously measured speed benchmarks to newly upserted variants.
+     * Replace, do not append: SQLite FKs are off by default so DELETE FROM
+     * variants does not cascade, and leftover rows would otherwise duplicate.
+     */
+    restoreSpeedBenchmarks(rows) {
+        this.run(`DELETE FROM benchmarks`);
+        if (!rows || rows.length === 0) return;
+
+        const insert = `
+            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second,
+                time_to_first_token, memory_used_gb, backend, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        `;
+
+        for (const row of rows) {
+            const variant = this.get(
+                `SELECT id FROM variants WHERE model_id = ? AND tag = ?`,
+                [row.model_id, row.tag]
+            );
+            if (!variant) continue;
+            this.run(insert, [
+                variant.id,
+                row.hardware_fingerprint,
+                row.tokens_per_second,
+                row.time_to_first_token,
+                row.memory_used_gb,
+                row.backend,
+                row.created_at || null
+            ]);
+        }
+    }
+
+    /**
+     * Clear catalog data. Local speed benchmarks are snapshotted by callers
+     * that recreate variants (variant_id is an autoincrement FK). Drop leftover
+     * benchmark rows here because SQLite FKs are off by default, so DELETE FROM
+     * variants does not cascade.
      */
     clear() {
         // The registry's Ollama source is derived from the local Ollama catalog.
         // Clear only that source so a classic Ollama sync does not erase HF/GPT4All data.
         this.clearRegistrySource('ollama');
-        this.run(`DELETE FROM benchmarks`);
         this.run(`DELETE FROM variants`);
         this.run(`DELETE FROM models`);
         this.run(`DELETE FROM sync_meta`);
+        this.run(`DELETE FROM benchmarks`);
     }
 
     /**

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -65,6 +65,7 @@ class ModelDatabase {
         this.useBetterSqlite = false;
 
         this.createSchema();
+        this.migrateSpeedBenchmarks();
         this.initialized = true;
         if (!this.disableRegistrySeedImport) {
             await this.seedRegistryFromPackagedSnapshotIfNeeded();
@@ -113,14 +114,16 @@ class ModelDatabase {
             -- Benchmarks table (real performance data per hardware)
             CREATE TABLE IF NOT EXISTS benchmarks (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                variant_id INTEGER NOT NULL,
+                variant_id INTEGER,
+                model_id TEXT,
+                tag TEXT,
                 hardware_fingerprint TEXT NOT NULL,
                 tokens_per_second REAL,
                 time_to_first_token REAL,
                 memory_used_gb REAL,
                 backend TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE CASCADE
+                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE SET NULL
             );
 
             -- Registry sources for multi-hub model discovery (Hugging Face,
@@ -239,6 +242,47 @@ class ModelDatabase {
         } else {
             this.db.run(schema);
             this.saveToFile();
+        }
+    }
+
+    migrateSpeedBenchmarks() {
+        if (this.all('PRAGMA table_info(benchmarks)').some((column) => column.name === 'model_id')) return;
+        // Preserve the original measurement ids/timestamps and backfill stable
+        // identities before any catalog refresh can replace variant row ids.
+        this.beginBatch();
+        try {
+            this.db.exec(`
+                SAVEPOINT migrate_speed_benchmarks;
+                CREATE TABLE benchmarks_stable (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    variant_id INTEGER,
+                    model_id TEXT,
+                    tag TEXT,
+                    hardware_fingerprint TEXT NOT NULL,
+                    tokens_per_second REAL,
+                    time_to_first_token REAL,
+                    memory_used_gb REAL,
+                    backend TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE SET NULL
+                );
+                INSERT INTO benchmarks_stable
+                SELECT b.id, v.id, v.model_id, v.tag, b.hardware_fingerprint,
+                       b.tokens_per_second, b.time_to_first_token, b.memory_used_gb,
+                       b.backend, b.created_at
+                FROM benchmarks b LEFT JOIN variants v ON v.id = b.variant_id;
+                DROP TABLE benchmarks;
+                ALTER TABLE benchmarks_stable RENAME TO benchmarks;
+                CREATE INDEX idx_benchmarks_hardware ON benchmarks(hardware_fingerprint);
+                CREATE INDEX idx_benchmarks_variant ON benchmarks(variant_id);
+                RELEASE migrate_speed_benchmarks;
+            `);
+            this._pendingSave = true;
+        } catch (error) {
+            this.db.exec('ROLLBACK TO migrate_speed_benchmarks; RELEASE migrate_speed_benchmarks;');
+            throw error;
+        } finally {
+            this.endBatch();
         }
     }
 
@@ -446,13 +490,17 @@ class ModelDatabase {
      * Add benchmark result
      */
     addBenchmark(benchmark) {
+        const variant = this.get('SELECT model_id, tag FROM variants WHERE id = ?', [benchmark.variant_id]);
+        if (!variant) throw new Error('Cannot record a benchmark for an unknown variant');
         const sql = `
-            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second, time_to_first_token, memory_used_gb, backend)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO benchmarks (variant_id, model_id, tag, hardware_fingerprint, tokens_per_second, time_to_first_token, memory_used_gb, backend)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         `;
 
         this.run(sql, [
             benchmark.variant_id,
+            variant.model_id,
+            variant.tag,
             benchmark.hardware_fingerprint,
             benchmark.tokens_per_second,
             benchmark.time_to_first_token,
@@ -1177,66 +1225,22 @@ class ModelDatabase {
         };
     }
 
-    /**
-     * Snapshot local speed telemetry keyed by model_id + tag so it can survive
-     * a force sync that recreates variant row ids.
-     */
-    snapshotSpeedBenchmarks() {
-        return this.all(`
-            SELECT v.model_id, v.tag, b.hardware_fingerprint, b.tokens_per_second,
-                   b.time_to_first_token, b.memory_used_gb, b.backend, b.created_at
-            FROM benchmarks b
-            JOIN variants v ON v.id = b.variant_id
-        `);
+    /** Reattach persisted telemetry after a catalog rebuild. Missing models keep
+     * their measurements, ready for a later sync that brings the tag back. */
+    reattachSpeedBenchmarks() {
+        this.run(`UPDATE benchmarks SET variant_id = (
+            SELECT v.id FROM variants v
+            WHERE v.model_id = benchmarks.model_id AND v.tag = benchmarks.tag
+        )`);
     }
 
-    /**
-     * Reattach previously measured speed benchmarks to newly upserted variants.
-     * Replace, do not append: SQLite FKs are off by default so DELETE FROM
-     * variants does not cascade, and leftover rows would otherwise duplicate.
-     */
-    restoreSpeedBenchmarks(rows) {
-        this.run(`DELETE FROM benchmarks`);
-        if (!rows || rows.length === 0) return;
-
-        const insert = `
-            INSERT INTO benchmarks (variant_id, hardware_fingerprint, tokens_per_second,
-                time_to_first_token, memory_used_gb, backend, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-        `;
-
-        for (const row of rows) {
-            const variant = this.get(
-                `SELECT id FROM variants WHERE model_id = ? AND tag = ?`,
-                [row.model_id, row.tag]
-            );
-            if (!variant) continue;
-            this.run(insert, [
-                variant.id,
-                row.hardware_fingerprint,
-                row.tokens_per_second,
-                row.time_to_first_token,
-                row.memory_used_gb,
-                row.backend,
-                row.created_at || null
-            ]);
-        }
-    }
-
-    /**
-     * Clear catalog data. Local speed benchmarks are snapshotted by callers
-     * that recreate variants (variant_id is an autoincrement FK). Drop leftover
-     * benchmark rows here because SQLite FKs are off by default, so DELETE FROM
-     * variants does not cascade.
-     */
+    /** Clear catalog data while preserving local measurements and their keys. */
     clear() {
-        // The registry's Ollama source is derived from the local Ollama catalog.
-        // Clear only that source so a classic Ollama sync does not erase HF/GPT4All data.
         this.clearRegistrySource('ollama');
-        this.run(`DELETE FROM variants`);
-        this.run(`DELETE FROM models`);
-        this.run(`DELETE FROM sync_meta`);
-        this.run(`DELETE FROM benchmarks`);
+        this.run('UPDATE benchmarks SET variant_id = NULL');
+        this.run('DELETE FROM variants');
+        this.run('DELETE FROM models');
+        this.run('DELETE FROM sync_meta');
     }
 
     /**

--- a/src/data/sync-manager.js
+++ b/src/data/sync-manager.js
@@ -52,7 +52,11 @@ class SyncManager {
         // times, turning the sync into O(n^2) disk I/O.
         this.db.beginBatch();
         try {
-            // Clear existing data
+            // Keep locally measured speed telemetry across force sync.
+            const speedBenchmarks = this.db.snapshotSpeedBenchmarks();
+
+            // Clear existing catalog data (variants/models). Benchmarks are
+            // re-keyed onto new variant ids after upsert.
             this.db.clear();
 
             // Scrape all models
@@ -62,6 +66,8 @@ class SyncManager {
                     this.db.upsertVariant(variant);
                 }
             });
+
+            this.db.restoreSpeedBenchmarks(speedBenchmarks);
 
             // Update sync timestamp
             this.db.setLastSync(new Date().toISOString());

--- a/src/data/sync-manager.js
+++ b/src/data/sync-manager.js
@@ -52,11 +52,9 @@ class SyncManager {
         // times, turning the sync into O(n^2) disk I/O.
         this.db.beginBatch();
         try {
-            // Keep locally measured speed telemetry across force sync.
-            const speedBenchmarks = this.db.snapshotSpeedBenchmarks();
-
-            // Clear existing catalog data (variants/models). Benchmarks are
-            // re-keyed onto new variant ids after upsert.
+            this.db.run('SAVEPOINT full_sync');
+            // Stable model/tag keys keep telemetry even when a model temporarily
+            // disappears from the catalog. Roll back failed refreshes as a unit.
             this.db.clear();
 
             // Scrape all models
@@ -67,10 +65,15 @@ class SyncManager {
                 }
             });
 
-            this.db.restoreSpeedBenchmarks(speedBenchmarks);
+            this.db.reattachSpeedBenchmarks();
 
             // Update sync timestamp
             this.db.setLastSync(new Date().toISOString());
+            this.db.run('RELEASE full_sync');
+        } catch (error) {
+            this.db.run('ROLLBACK TO full_sync');
+            this.db.run('RELEASE full_sync');
+            throw error;
         } finally {
             this.db.endBatch();
         }

--- a/tests/database-backends.test.js
+++ b/tests/database-backends.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const Module = require('module');
+const ModelDatabase = require('../src/data/model-database');
+
+async function run() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-sqlite-'));
+    let nativeAvailable = false;
+    try { nativeAvailable = Boolean(require('node:sqlite').DatabaseSync); } catch {}
+    const modes = nativeAvailable ? ['wasm', 'native'] : ['wasm'];
+    const outputs = [];
+    try {
+        for (const sqliteBackend of modes) {
+            const options = { dbPath: path.join(dir, `${sqliteBackend}.db`), sqliteBackend };
+            const db = new ModelDatabase(options);
+            try {
+                await db.initialize();
+                assert.strictEqual(db.useNativeSqlite, sqliteBackend === 'native');
+                outputs.push(db.all('SELECT * FROM model_artifacts ORDER BY id'));
+                assert.strictEqual(db.get('SELECT id FROM models WHERE id = ?', ['missing-model']), null);
+                db.beginBatch(); db.beginBatch();
+                db.upsertModel({ id: 'test-model', name: "Quoted ' model", description: 'Unicode: café 日本語' });
+                db.upsertVariant({ model_id: 'test-model', tag: 'test-model:1b', params_b: 1, size_gb: 0.5 });
+                db.endBatch(); db.endBatch();
+                db.close();
+                await db.initialize();
+                assert.strictEqual(db.get('SELECT description FROM models WHERE id = ?', ['test-model']).description, 'Unicode: café 日本語');
+                assert.strictEqual(db.get('SELECT params_b FROM variants WHERE model_id = ?', ['test-model']).params_b, 1);
+                assert.throws(() => db.all('SELECT missing_column FROM models'));
+                assert.strictEqual(db.get('SELECT 1 AS n').n, 1, 'query errors leave the connection usable');
+            } finally { db.close(); }
+        }
+        if (outputs.length === 2) assert.deepStrictEqual(outputs[1], outputs[0], 'native and WASM return the same full catalog');
+
+        // Auto mode must work when Node has no built-in SQLite. Conversely,
+        // supported Node versions must never require the optional WASM package.
+        const originalLoad = Module._load;
+        for (const block of nativeAvailable ? ['node:sqlite', 'sql.js'] : ['node:sqlite']) {
+            const db = new ModelDatabase({ dbPath: path.join(dir, `auto-${block.replace(/\W/g, '-')}.db`) });
+            Module._load = function(id, ...args) {
+                if (id === block) {
+                    const error = new Error(`Unavailable: ${id}`);
+                    error.code = 'MODULE_NOT_FOUND';
+                    throw error;
+                }
+                return originalLoad.call(this, id, ...args);
+            };
+            try {
+                await db.initialize();
+                assert.strictEqual(db.useNativeSqlite, block === 'sql.js');
+                assert.ok(db.getModelCount() > 100);
+            } finally { Module._load = originalLoad; db.close(); }
+        }
+        console.log(`database-backends.test.js: OK (${modes.join(', ')})`);
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+if (require.main === module) run().catch((error) => { console.error(error); process.exitCode = 1; });
+module.exports = { run };

--- a/tests/model-registry-seed.test.js
+++ b/tests/model-registry-seed.test.js
@@ -7,9 +7,10 @@ const ModelDatabase = require('../src/data/model-database');
 
 async function run() {
     const seedDbPath = path.join(__dirname, '..', 'src', 'data', 'seed', 'models.db');
+    const seedTestDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-seed-test-'));
     const database = new ModelDatabase({
-        dbPath: seedDbPath,
-        seedDbPath: path.join(__dirname, 'missing-seed.db')
+        dbPath: path.join(seedTestDir, 'models.db'),
+        seedDbPath
     });
 
     try {
@@ -68,6 +69,7 @@ async function run() {
         console.log('[OK] model-registry-seed.test.js passed');
     } finally {
         database.close();
+        fs.rmSync(seedTestDir, { recursive: true, force: true });
     }
 }
 

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -49,6 +49,7 @@ const TESTS = [
     { name: 'CLI interactive panel helpers', file: 'cli-interactive-panel.test.js', category: 'UI' },
     { name: 'Windows panel overflow + resize', file: 'windows-panel-overflow.test.js', category: 'UI' },
     { name: 'Local features end-to-end', file: 'local-features-e2e.test.js', category: 'E2E' },
+    { name: 'Speed telemetry survives sync', file: 'speed-benchmark-sync-restore.test.js', category: 'Calibration' },
     { name: 'Calibration schema', file: 'calibration-schema.test.js', category: 'Calibration' },
     { name: 'Calibration command', file: 'calibrate-command.test.js', category: 'Calibration' },
     { name: 'Calibration end-to-end', file: 'calibration-e2e-integration.test.js', category: 'Calibration' },

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -49,6 +49,7 @@ const TESTS = [
     { name: 'CLI interactive panel helpers', file: 'cli-interactive-panel.test.js', category: 'UI' },
     { name: 'Windows panel overflow + resize', file: 'windows-panel-overflow.test.js', category: 'UI' },
     { name: 'Local features end-to-end', file: 'local-features-e2e.test.js', category: 'E2E' },
+    { name: 'SQLite backend compatibility', file: 'database-backends.test.js', category: 'Performance' },
     { name: 'Speed telemetry survives sync', file: 'speed-benchmark-sync-restore.test.js', category: 'Calibration' },
     { name: 'Calibration schema', file: 'calibration-schema.test.js', category: 'Calibration' },
     { name: 'Calibration command', file: 'calibrate-command.test.js', category: 'Calibration' },

--- a/tests/speed-benchmark-sync-restore.test.js
+++ b/tests/speed-benchmark-sync-restore.test.js
@@ -4,6 +4,7 @@ const os = require('os');
 const path = require('path');
 
 const ModelDatabase = require('../src/data/model-database');
+const SyncManager = require('../src/data/sync-manager');
 
 async function withTempDb(fn) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-speed-restore-'));
@@ -37,24 +38,67 @@ function seedSpeedRow(database) {
 }
 
 async function run() {
+    for (const foreignKeys of [false, true]) {
+        await withTempDb(async (database) => {
+            database.run(`PRAGMA foreign_keys = ${foreignKeys ? 'ON' : 'OFF'}`);
+            const oldVariant = seedSpeedRow(database);
+            const original = database.all('SELECT * FROM benchmarks')[0];
+            const scraper = { scrapeAll: async (onModel) => {
+                onModel({ id: 'llama3', name: 'llama3' }, [{ model_id: 'llama3', tag: '8b' }]);
+            } };
+            const sync = new SyncManager({ database, scraper, onProgress() {} });
+            await sync.fullSync();
+            const variant = database.get("SELECT id FROM variants WHERE model_id = 'llama3'");
+            assert.notStrictEqual(variant.id, oldVariant.id, 'variant ids change during a rebuild');
+            assert.deepStrictEqual(database.getBenchmarks(variant.id)[0], { ...original, variant_id: variant.id });
+            database.reattachSpeedBenchmarks();
+            assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1, 'reattachment never duplicates measurements');
+
+            const beforeFailure = database.all('SELECT * FROM benchmarks');
+            scraper.scrapeAll = async () => { throw new Error('network unavailable'); };
+            await assert.rejects(sync.fullSync(), /network unavailable/);
+            assert.deepStrictEqual(database.all('SELECT * FROM benchmarks'), beforeFailure);
+            assert.strictEqual(database.getVariantCount(), 1, 'failed sync rolls the catalog back too');
+
+            scraper.scrapeAll = async () => {};
+            await sync.fullSync();
+            assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1, 'missing model keeps telemetry');
+            assert.strictEqual(database.all('SELECT * FROM benchmarks')[0].variant_id, null);
+            // Persistence matters: an in-memory snapshot is insufficient across restarts.
+            database.close(); database.db = null; database.initialized = false;
+            await database.initialize();
+            scraper.scrapeAll = async (onModel) => {
+                onModel({ id: 'llama3', name: 'llama3' }, [{ model_id: 'llama3', tag: '8b' }]);
+            };
+            await sync.fullSync();
+            const returned = database.get("SELECT id FROM variants WHERE model_id = 'llama3'");
+            assert.deepStrictEqual(database.getBenchmarks(returned.id)[0], { ...original, variant_id: returned.id });
+        });
+    }
+
     await withTempDb((database) => {
-        seedSpeedRow(database);
-        const snapshot = database.snapshotSpeedBenchmarks();
-        assert.strictEqual(snapshot.length, 1);
-
+        const variant = seedSpeedRow(database);
+        // Recreate the shipped pre-migration schema, with real historical data.
+        database.db.exec(`
+            DROP TABLE benchmarks;
+            CREATE TABLE benchmarks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, variant_id INTEGER NOT NULL,
+                hardware_fingerprint TEXT NOT NULL, tokens_per_second REAL,
+                time_to_first_token REAL, memory_used_gb REAL, backend TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (variant_id) REFERENCES variants(id) ON DELETE CASCADE
+            );
+            INSERT INTO benchmarks VALUES (17, ${variant.id}, 'legacy-hw', 42.5, 0.2, 5.1, 'cpu', '2026-01-01');
+        `);
+        database.migrateSpeedBenchmarks();
+        database.migrateSpeedBenchmarks();
+        const migrated = database.all('SELECT * FROM benchmarks')[0];
+        assert.strictEqual(migrated.model_id, 'llama3');
+        assert.strictEqual(migrated.tag, '8b');
+        assert.strictEqual(migrated.id, 17);
+        assert.strictEqual(migrated.created_at, '2026-01-01');
         database.clear();
-        assert.strictEqual(database.get(`SELECT COUNT(*) as count FROM benchmarks`).count, 0);
-
-        database.upsertModel({ id: 'llama3', name: 'llama3' });
-        database.upsertVariant({ model_id: 'llama3', tag: '8b' });
-        database.restoreSpeedBenchmarks(snapshot);
-        database.restoreSpeedBenchmarks(snapshot);
-
-        const restored = database.all(`SELECT tokens_per_second, hardware_fingerprint FROM benchmarks`);
-        assert.strictEqual(restored.length, 1, 'restore must replace, not append');
-        assert.strictEqual(restored[0].tokens_per_second, 42.5);
-        assert.strictEqual(restored[0].hardware_fingerprint, 'hw-1');
-        assert.strictEqual(database.snapshotSpeedBenchmarks().length, 1);
+        assert.strictEqual(database.all('SELECT * FROM benchmarks').length, 1);
     });
 
     console.log('[OK] speed-benchmark-sync-restore.test.js passed');

--- a/tests/speed-benchmark-sync-restore.test.js
+++ b/tests/speed-benchmark-sync-restore.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ModelDatabase = require('../src/data/model-database');
+
+async function withTempDb(fn) {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-speed-restore-'));
+    const database = new ModelDatabase({
+        dbPath: path.join(tempDir, 'models.db'),
+        seedDbPath: path.join(tempDir, 'missing-seed.db'),
+        disableRegistrySeedImport: true
+    });
+    try {
+        await database.initialize();
+        await fn(database);
+    } finally {
+        database.close();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+function seedSpeedRow(database) {
+    database.upsertModel({ id: 'llama3', name: 'llama3' });
+    database.upsertVariant({ model_id: 'llama3', tag: '8b' });
+    const variant = database.get(`SELECT id FROM variants WHERE model_id = ? AND tag = ?`, ['llama3', '8b']);
+    database.addBenchmark({
+        variant_id: variant.id,
+        hardware_fingerprint: 'hw-1',
+        tokens_per_second: 42.5,
+        time_to_first_token: 0.2,
+        memory_used_gb: 5.1,
+        backend: 'cpu'
+    });
+    return variant;
+}
+
+async function run() {
+    await withTempDb((database) => {
+        seedSpeedRow(database);
+        const snapshot = database.snapshotSpeedBenchmarks();
+        assert.strictEqual(snapshot.length, 1);
+
+        database.clear();
+        assert.strictEqual(database.get(`SELECT COUNT(*) as count FROM benchmarks`).count, 0);
+
+        database.upsertModel({ id: 'llama3', name: 'llama3' });
+        database.upsertVariant({ model_id: 'llama3', tag: '8b' });
+        database.restoreSpeedBenchmarks(snapshot);
+        database.restoreSpeedBenchmarks(snapshot);
+
+        const restored = database.all(`SELECT tokens_per_second, hardware_fingerprint FROM benchmarks`);
+        assert.strictEqual(restored.length, 1, 'restore must replace, not append');
+        assert.strictEqual(restored[0].tokens_per_second, 42.5);
+        assert.strictEqual(restored[0].hardware_fingerprint, 'hw-1');
+        assert.strictEqual(database.snapshotSpeedBenchmarks().length, 1);
+    });
+
+    console.log('[OK] speed-benchmark-sync-restore.test.js passed');
+}
+
+if (require.main === module) {
+    run().catch((error) => {
+        console.error('[FAIL] speed-benchmark-sync-restore.test.js failed');
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = { run };


### PR DESCRIPTION
Use `node:sqlite` when available and retain `sql.js` for older Node runtimes. The native connection reads the database file directly, and nested write batches use SQLite savepoints. Preserve plain-object result rows, null for missing rows, database reopen behavior and catalog migrations. File-opening errors surface rather than silently retrying another engine.

Validation: compare all 32,779 packaged artifact rows across both engines; exercise persisted writes, nested batches, reopen, query failures, missing built-in SQLite and missing optional sql.js. Telemetry migration/restore and registry tests pass. Three separate-process measurements per engine on Node 22: median query 397.3 → 265.5 ms, initialization 76.3 → 10.4 ms, peak RSS 226.8 → 185.4 MB. No new dependency.

Closes #125.
