### PR TITLE
fix(runtime): honor llama.cpp, Transformers, and explicit runtime choices

### DIFF
--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -2891,10 +2891,10 @@ async function displayModelRecommendations(analysis, hardware, useCase = 'genera
                 }
             } else {
                 console.log(`Status: ${chalk.gray(`${runtimeLabel} runtime selected`)}`);
-                console.log(`\nRun: ${chalk.cyan.bold(runtimeCommands.run)}`);
+                console.log(`\nRun: ${runtimeCommands.run ? chalk.cyan.bold(runtimeCommands.run) : chalk.yellow('Select a matching repository or local model file for this runtime.')}`);
                 if (index === 0) {
-                    console.log(`Install runtime: ${chalk.cyan.bold(runtimeCommands.install)}`);
-                    console.log(`Fetch model: ${chalk.cyan.bold(runtimeCommands.pull)}`);
+                    if (runtimeCommands.install) console.log(`Install runtime: ${chalk.cyan.bold(runtimeCommands.install)}`);
+                    if (runtimeCommands.pull) console.log(`Fetch model: ${chalk.cyan.bold(runtimeCommands.pull)}`);
                 }
             }
 
@@ -2956,6 +2956,10 @@ async function displayQuickStartCommands(analysis, recommendedModel = null, allR
         }
 
         const runtimeCommands = getRuntimeCommandSet(bestModel, selectedRuntime);
+        if (!runtimeCommands.run || !runtimeCommands.pull) {
+            console.log(chalk.yellow(`Select a matching repository or local model file for ${runtimeLabel}.`));
+            return;
+        }
         console.log(`1. Install ${runtimeLabel}:`);
         console.log(`   ${chalk.cyan.bold(runtimeCommands.install)}`);
         console.log(`2. Fetch model weights:`);
@@ -3538,6 +3542,7 @@ auditCommand
 
             if (selectedCommand === 'check') {
                 let selectedRuntime = normalizeRuntime(options.runtime);
+                if (!selectedRuntime) throw new Error(`Invalid --runtime: ${options.runtime}`);
                 if (!runtimeSupportedOnHardware(selectedRuntime, hardware)) {
                     selectedRuntime = 'ollama';
                 }
@@ -3872,6 +3877,7 @@ Policy scope:
 
             const hardware = await checker.getSystemInfo();
             let selectedRuntime = normalizeRuntime(options.runtime);
+            if (!selectedRuntime) throw new Error(`Invalid --runtime: ${options.runtime}`);
             if (!runtimeSupportedOnHardware(selectedRuntime, hardware)) {
                 const runtimeLabel = getRuntimeDisplayName(selectedRuntime);
                 console.log(
@@ -4522,7 +4528,8 @@ Calibrated routing examples:
             }
 
             const hardware = await checker.getSystemInfo();
-            let recommendationRuntime = options.runtime;
+            let recommendationRuntime = normalizeRuntime(options.runtime);
+            if (!recommendationRuntime) throw new Error(`Invalid --runtime: ${options.runtime}`);
             const requestedRuntimeName = String(options.runtime || 'auto').toLowerCase();
             if (
                 !['auto', 'all', '*'].includes(requestedRuntimeName) &&

--- a/src/calibration/calibration-manager.js
+++ b/src/calibration/calibration-manager.js
@@ -12,7 +12,9 @@ const {
     calibrationPolicySchema,
     DEFAULT_CALIBRATION_TASK
 } = require('./schemas');
-const { SUPPORTED_RUNTIMES, normalizeRuntime } = require('../runtime/runtime-support');
+const { normalizeRuntime } = require('../runtime/runtime-support');
+// Calibration adapters currently implement these three runtimes only.
+const SUPPORTED_RUNTIMES = ['ollama', 'vllm', 'mlx'];
 
 const SUPPORTED_FULL_MODE_RUNTIMES = ['ollama'];
 

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -2,7 +2,7 @@ const ModelDatabase = require('./model-database');
 const { isSupportedHuggingFaceModel } = require('./registry-ingestors');
 const DeterministicModelSelector = require('../models/deterministic-selector');
 const { applyCpuOnlyOverride } = require('../hardware/cpu-only');
-const { runtimeSupportedOnHardware } = require('../runtime/runtime-support');
+const { runtimeSupportedOnHardware, normalizeRuntime } = require('../runtime/runtime-support');
 
 function toArray(value) {
     return Array.isArray(value) ? value : [];
@@ -458,7 +458,8 @@ class RegistryRecommender {
                 ? { cpuOnly: options.cpuOnly }
                 : {})
         });
-        const requestedRuntime = options.runtime || 'auto';
+        const requestedRuntime = normalizeRuntime(options.runtime || 'auto');
+        if (!requestedRuntime) throw new Error(`Unsupported runtime: ${options.runtime}`);
         const requestedRuntimeName = String(requestedRuntime).toLowerCase();
         const runtime = !['auto', 'all', '*'].includes(requestedRuntimeName) &&
             !runtimeSupportedOnHardware(requestedRuntime, selectorHardware)

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,9 @@ function normalizeRecommendationRuntime(runtime = 'auto') {
         if (normalized === 'hf') return 'transformers';
         return normalized;
     }
-    return normalizeRuntime(normalized);
+    const runtimeName = normalizeRuntime(normalized);
+    if (!runtimeName) throw new Error(`Unsupported runtime: ${runtime}`);
+    return runtimeName;
 }
 
 class LLMChecker {

--- a/src/runtime/runtime-support.js
+++ b/src/runtime/runtime-support.js
@@ -1,16 +1,21 @@
-const SUPPORTED_RUNTIMES = ['ollama', 'vllm', 'mlx'];
+const SUPPORTED_RUNTIMES = ['ollama', 'vllm', 'mlx', 'llama.cpp', 'transformers'];
 const { normalizePlatform, isTermuxEnvironment } = require('../utils/platform');
 
 function normalizeRuntime(runtime = 'ollama') {
-    const normalized = String(runtime || 'ollama').trim().toLowerCase();
-    return SUPPORTED_RUNTIMES.includes(normalized) ? normalized : 'ollama';
+    const normalized = String(runtime ?? '').trim().toLowerCase();
+    const aliases = { llamacpp: 'llama.cpp', llama_cpp: 'llama.cpp', hf: 'transformers', all: 'auto', '*': 'auto' };
+    const name = aliases[normalized] || normalized;
+    return name === 'auto' || SUPPORTED_RUNTIMES.includes(name) ? name : null;
 }
 
 function getRuntimeDisplayName(runtime = 'ollama') {
     const normalized = normalizeRuntime(runtime);
     if (normalized === 'vllm') return 'vLLM';
     if (normalized === 'mlx') return 'MLX-LM';
-    return 'Ollama';
+    if (normalized === 'llama.cpp') return 'llama.cpp';
+    if (normalized === 'transformers') return 'Transformers';
+    if (normalized === 'auto') return 'Automatic';
+    return normalized === 'ollama' ? 'Ollama' : 'Unknown runtime';
 }
 
 function isAppleSiliconHardware(hardware = {}) {
@@ -39,6 +44,7 @@ function isAppleSiliconHardware(hardware = {}) {
 
 function runtimeSupportedOnHardware(runtime = 'ollama', hardware = {}) {
     const normalized = normalizeRuntime(runtime);
+    if (!normalized) return false;
     if (normalized === 'mlx') {
         if (hardware?.cpuOnly) return false;
         return isAppleSiliconHardware(hardware);
@@ -70,12 +76,14 @@ function slugifyModelName(text = '') {
 }
 
 function getRuntimeModelRef(model = {}, runtime = 'ollama') {
-    const normalized = normalizeRuntime(runtime);
+    const normalized = resolveCommandRuntime(model, runtime);
+    if (!normalized) return null;
 
     const candidates = [
         model.hfModel,
         model.hfId,
         model.huggingfaceId,
+        ...(normalized !== 'ollama' ? [model.artifact?.repo_id, model.repo_id] : []),
         model.model_identifier,
         model.identifier,
         model.cloudData?.identifier,
@@ -92,6 +100,10 @@ function getRuntimeModelRef(model = {}, runtime = 'ollama') {
         return raw;
     }
 
+    // An Ollama tag is not a Hugging Face repository. Do not invent a repo for
+    // a GGUF/Transformers workflow when the catalog does not provide one.
+    if (['llama.cpp', 'transformers'].includes(normalized) && raw.includes(':') && !raw.includes('/')) return null;
+
     if (raw.includes('/')) {
         return raw;
     }
@@ -107,6 +119,13 @@ function getRuntimeModelRef(model = {}, runtime = 'ollama') {
 
 function getRuntimeInstallCommand(runtime = 'ollama') {
     const normalized = normalizeRuntime(runtime);
+    if (!normalized || normalized === 'auto') return null;
+    if (normalized === 'transformers') return 'python -m pip install -U transformers torch huggingface_hub';
+    if (normalized === 'llama.cpp') {
+        if (normalizePlatform() === 'win32') return 'winget install llama.cpp';
+        if (normalizePlatform() === 'darwin') return 'brew install llama.cpp';
+        return 'conda install -c conda-forge llama.cpp';
+    }
 
     if (normalized === 'vllm') {
         return 'pip install -U "vllm>=0.6.0"';
@@ -132,8 +151,17 @@ function getRuntimeInstallCommand(runtime = 'ollama') {
 }
 
 function getRuntimePullCommand(model = {}, runtime = 'ollama') {
-    const normalized = normalizeRuntime(runtime);
-    const modelRef = getRuntimeModelRef(model, runtime);
+    const normalized = resolveCommandRuntime(model, runtime);
+    const modelRef = getRuntimeModelRef(model, normalized);
+    if (!normalized || !modelRef) return null;
+    if (normalized === 'transformers') return `hf download ${shellEscapeArg(modelRef)}`;
+    if (normalized === 'llama.cpp') {
+        const file = getGgufFilename(model);
+        if (!file || !modelRef.includes('/')) return null;
+        const url = model.artifact?.download_url || model.downloadUrl ||
+            `https://huggingface.co/${modelRef}/resolve/main/${file.split('/').map(encodeURIComponent).join('/')}`;
+        return `curl --fail --location ${shellEscapeArg(url)} --output ${shellEscapeArg(`./${file.split('/').pop()}`)}`;
+    }
 
     if (normalized === 'vllm') {
         return `huggingface-cli download ${shellEscapeArg(modelRef)}`;
@@ -148,8 +176,18 @@ function getRuntimePullCommand(model = {}, runtime = 'ollama') {
 }
 
 function getRuntimeRunCommand(model = {}, runtime = 'ollama') {
-    const normalized = normalizeRuntime(runtime);
-    const modelRef = getRuntimeModelRef(model, runtime);
+    const normalized = resolveCommandRuntime(model, runtime);
+    const modelRef = getRuntimeModelRef(model, normalized);
+    if (!normalized || !modelRef) return null;
+    if (normalized === 'llama.cpp') {
+        const file = getGgufFilename(model);
+        if (!file) return null;
+        return `llama-cli --model ${shellEscapeArg(model.localPath || `./${file.split('/').pop()}`)} --prompt "Hello" --n-predict 64 --single-turn`;
+    }
+    if (normalized === 'transformers') {
+        const script = 'import sys; from transformers import pipeline; print(pipeline("text-generation", model=sys.argv[1])("Hello", max_new_tokens=64)[0]["generated_text"])';
+        return `python -c ${shellEscapeArg(script)} ${shellEscapeArg(modelRef)}`;
+    }
 
     if (normalized === 'vllm') {
         return `python -m vllm.entrypoints.openai.api_server --model ${shellEscapeArg(modelRef)} --host 0.0.0.0 --port 8000`;
@@ -163,7 +201,7 @@ function getRuntimeRunCommand(model = {}, runtime = 'ollama') {
 }
 
 function getRuntimeCommandSet(model = {}, runtime = 'ollama') {
-    const normalized = normalizeRuntime(runtime);
+    const normalized = resolveCommandRuntime(model, runtime);
     return {
         runtime: normalized,
         displayName: getRuntimeDisplayName(normalized),
@@ -172,6 +210,21 @@ function getRuntimeCommandSet(model = {}, runtime = 'ollama') {
         pull: getRuntimePullCommand(model, normalized),
         run: getRuntimeRunCommand(model, normalized)
     };
+}
+
+function getGgufFilename(model) {
+    const file = model.artifact?.filename || model.filename || model.localPath || '';
+    return /\.gguf$/i.test(file) ? file : null;
+}
+
+function resolveCommandRuntime(model, runtime) {
+    const normalized = normalizeRuntime(runtime);
+    if (normalized !== 'auto') return normalized;
+    const preferred = normalizeRuntime(model.preferredRuntime || model.runtime || null);
+    if (preferred && preferred !== 'auto') return preferred;
+    if (getGgufFilename(model) || model.artifact?.format === 'gguf') return 'llama.cpp';
+    if (model.hfModel || model.hfId || model.huggingfaceId || model.artifact?.source_id === 'huggingface') return 'transformers';
+    return 'ollama';
 }
 
 module.exports = {

--- a/tests/runtime-specdec-tests.js
+++ b/tests/runtime-specdec-tests.js
@@ -15,7 +15,37 @@ function runRuntimeCommandTests() {
 
     assert.strictEqual(normalizeRuntime('VLLM'), 'vllm');
     assert.strictEqual(normalizeRuntime('mlx'), 'mlx');
-    assert.strictEqual(normalizeRuntime('unknown-runtime'), 'ollama');
+    assert.strictEqual(normalizeRuntime('unknown-runtime'), null);
+    assert.strictEqual(normalizeRuntime('auto'), 'auto');
+    assert.strictEqual(normalizeRuntime('llama.cpp'), 'llama.cpp');
+    assert.strictEqual(normalizeRuntime('HF'), 'transformers');
+    assert.strictEqual(runtimeSupportedOnHardware('typo'), false);
+    const invalid = getRuntimeCommandSet(model, 'unknown-runtime');
+    assert.strictEqual(invalid.runtime, null);
+    assert.strictEqual(invalid.pull, null);
+    assert.strictEqual(invalid.run, null);
+
+    const gguf = { hfId: 'ggml-org/models', filename: 'tinyllamas/stories260K.gguf' };
+    const cpp = getRuntimeCommandSet(gguf, 'llama.cpp');
+    assert.ok(cpp.install.includes('llama.cpp'));
+    assert.ok(cpp.pull.includes('curl --fail --location'));
+    assert.ok(cpp.pull.includes('/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf'));
+    assert.ok(cpp.run.includes("llama-cli --model './stories260K.gguf'"));
+    assert.deepStrictEqual(getRuntimeCommandSet(gguf, 'auto'), cpp);
+    assert.strictEqual(getRuntimeCommandSet(model, 'llama.cpp').run, null, 'an Ollama tag is not a GGUF file');
+    const transformers = getRuntimeCommandSet({ hfId: 'HuggingFaceTB/SmolLM2-135M' }, 'transformers');
+    assert.ok(transformers.install.includes('transformers torch'));
+    assert.ok(transformers.pull.includes("hf download 'HuggingFaceTB/SmolLM2-135M'"));
+    assert.ok(transformers.run.includes('from transformers import pipeline'));
+    assert.strictEqual(getRuntimeCommandSet({ hfId: 'HuggingFaceTB/SmolLM2-135M' }, 'auto').runtime, 'transformers');
+    assert.strictEqual(getRuntimeCommandSet(model, 'auto').runtime, 'ollama');
+    const { spawnSync } = require('child_process');
+    const path = require('path');
+    const invalidCli = spawnSync(process.execPath, [path.join(__dirname, '../bin/enhanced_cli.js'),
+        'check', '--simulate', 'rtx4090', '--runtime', 'unknown-runtime', '--no-verbose'], { encoding: 'utf8' });
+    assert.notStrictEqual(invalidCli.status, 0);
+    assert.match(invalidCli.stdout + invalidCli.stderr, /Invalid --runtime/);
+    assert.doesNotMatch(invalidCli.stdout + invalidCli.stderr, /Falling back to Ollama/);
 
     const ollamaCmds = getRuntimeCommandSet(model, 'ollama');
     assert.ok(ollamaCmds.pull.includes('ollama pull'));


### PR DESCRIPTION
Closes #123.

Requesting `llama.cpp`, `transformers`, `auto`, or an unknown runtime previously produced Ollama commands. Runtime normalization now preserves supported names and aliases, preserves `auto`, and returns null for invalid input. CLI and library entry points reject an invalid explicit selection.

The command builder supplies GGUF download and llama-cli commands for llama.cpp, and Hugging Face download plus Python generation commands for Transformers. Automatic selection uses the model's runtime and artifact metadata. Missing GGUF/repository information produces no fabricated command. Calibration retains its existing three supported adapters.

Validation:
- Full local suite: 61/61; runtime, registry, CLI, calibration and Termux regressions pass.
- Executed the generated download and generation commands with the installed llama.cpp build 10678 and `ggml-org/models/tinyllamas/stories260K.gguf`: 64 generated tokens, exit 0. Real execution exposed the need for `--single-turn`, which is included.
- Executed the exact generated Transformers download and generation commands for `HuggingFaceTB/SmolLM2-135M` in an isolated Python 3.12 environment (Transformers 5.16.1, Torch 2.14.0 CPU): download completed in 99.5 s, 64-token generation completed in 9.4 s, both exit 0. Platform-specific installation commands were reviewed against upstream documentation; they were not all executed.
